### PR TITLE
Update to Istio 1.29.0-alpha.0

### DIFF
--- a/bin/meshlab
+++ b/bin/meshlab
@@ -28,7 +28,7 @@ OTEL_COLLECTOR_CHART_VERSION='0.143.0'        # https://artifacthub.io/packages/
 VAULT_CHART_VERSION='0.31.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
 CERT_MANAGER_CHART_VERSION='v1.19.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
 KUBERNETES_REPLICATOR_CHART_VERSION='2.12.2'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
-ISTIO_CHART_VERSION='1.28.2'                  # https://artifacthub.io/packages/helm/istio-official/base
+ISTIO_CHART_VERSION='1.29.0-alpha.0'          # https://artifacthub.io/packages/helm/istio-official/base
 KIALI_CHART_VERSION='2.20.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
 
 #------------------------------------------------------------------------------

--- a/bin/retoken
+++ b/bin/retoken
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script helps reproduce a memory leak in istiod that occurs when updating
-# the istio-remote-secret with a new access token. It performs 100 retokenings
+# the istio-remote-secret with a new access token. It performs 200 retokenings
 # and collects 11 heap profile samples: one initial sample and one after every
 # 10 retokenings.
 
@@ -60,9 +60,9 @@ curl -s "http://localhost:${ISTIOD_DEBUG_PORT}/debug/pprof/heap?gc=1" > heap.sam
 
 # Run retoken and take heap profile sample every 10 retokenings
 sample=1
-for i in {1..100}; do
+for i in {1..200}; do
   ${RETOKEN}
-  sleep 10
+  sleep 5
   if (( i % 10 == 0 )); then
     echo "Taking heap profile sample ${sample}"
     curl -s "http://localhost:${ISTIOD_DEBUG_PORT}/debug/pprof/heap?gc=1" > heap.sample-"${sample}".pb.gz

--- a/bin/retoken
+++ b/bin/retoken
@@ -2,7 +2,7 @@
 
 # This script helps reproduce a memory leak in istiod that occurs when updating
 # the istio-remote-secret with a new access token. It performs 200 retokenings
-# and collects 11 heap profile samples: one initial sample and one after every
+# and collects 21 heap profile samples: one initial sample and one after every
 # 10 retokenings.
 
 SRC_CLUSTER="pasta-1"

--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -28,7 +28,7 @@ spec:
             revision: {{ .Values.chartVersion | replace "." "-" }}
             revisionTags: [ "stable", "canary" ]
             pilot:
-              image: ghcr.io/h0tbird/pilot:1.28.2-patch.1
+            # image: ghcr.io/h0tbird/pilot:1.28.2-patch.1
               autoscaleEnabled: false
               env:
                 AUTO_RELOAD_PLUGIN_CERTS: true
@@ -37,9 +37,9 @@ spec:
                 ISTIOD_CUSTOM_HOST: {{`'istiod.{{name}}'`}}
                 ENABLE_NATIVE_SIDECARS: true
             global:
-              hub: ghcr.io/h0tbird
-              tag: 1.28.2-patch.1
-              variant: ""
+            # hub: ghcr.io/h0tbird
+            # tag: 1.28.2-patch.1
+            # variant: ""
               meshID: {{`'{{metadata.labels.cell}}'`}}
               network: {{`'{{metadata.labels.cell}}'`}}
               logAsJson: true


### PR DESCRIPTION
Memory remains stable under aggressive retokening:

<img width="1386" height="1338" alt="Screenshot 2026-01-14 at 16 59 31" src="https://github.com/user-attachments/assets/87407c9d-a6fc-4464-8bea-734583b4809f" />