### PR TITLE
Testing 1-28-20b115b

### DIFF
--- a/bin/meshlab
+++ b/bin/meshlab
@@ -28,7 +28,7 @@ OTEL_COLLECTOR_CHART_VERSION='0.143.0'        # https://artifacthub.io/packages/
 VAULT_CHART_VERSION='0.31.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
 CERT_MANAGER_CHART_VERSION='v1.19.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
 KUBERNETES_REPLICATOR_CHART_VERSION='2.12.2'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
-ISTIO_CHART_VERSION='1.29.0-alpha.0'          # https://artifacthub.io/packages/helm/istio-official/base
+ISTIO_CHART_VERSION='1.28.2'                  # https://artifacthub.io/packages/helm/istio-official/base
 KIALI_CHART_VERSION='2.20.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
 
 #------------------------------------------------------------------------------

--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -28,7 +28,7 @@ spec:
             revision: {{ .Values.chartVersion | replace "." "-" }}
             revisionTags: [ "stable", "canary" ]
             pilot:
-            # image: ghcr.io/h0tbird/pilot:1.28.2-patch.1
+              image: gcr.io/istio-testing/pilot:1.28-alpha.20b115b06e4a6105b0a264b6cc58e1caa2776451
               autoscaleEnabled: false
               env:
                 AUTO_RELOAD_PLUGIN_CERTS: true
@@ -37,9 +37,9 @@ spec:
                 ISTIOD_CUSTOM_HOST: {{`'istiod.{{name}}'`}}
                 ENABLE_NATIVE_SIDECARS: true
             global:
-            # hub: ghcr.io/h0tbird
-            # tag: 1.28.2-patch.1
-            # variant: ""
+              hub: gcr.io/istio-testing
+              tag: 1.28-alpha.20b115b06e4a6105b0a264b6cc58e1caa2776451
+              variant: ""
               meshID: {{`'{{metadata.labels.cell}}'`}}
               network: {{`'{{metadata.labels.cell}}'`}}
               logAsJson: true


### PR DESCRIPTION
Testing the image below...
```console
$ k --context kind-pasta-1 -n istio-system get deploy/istiod-1-28-2 -o yaml | grep 'image: '
        image: gcr.io/istio-testing/pilot:1.28-alpha.20b115b06e4a6105b0a264b6cc58e1caa2776451
```

...memory goes [up and to the right](https://snapshots.raintank.io/dashboard/snapshot/wfy3WWOogTbRbRBqGFzUHBbzMDmuFK5w?orgId=0&refresh=10s) when I run aggressive [retokening](https://github.com/h0tbird/meshlab/blob/master/bin/retoken):

<img width="1694" height="836" alt="Screenshot 2026-01-15 at 11 56 16" src="https://github.com/user-attachments/assets/35a1fa4e-a80e-41e5-8aa8-04c7ad2bf544" />

```console
$ go tool pprof -http=:9999 -diff_base heap.sample-0.pb.gz heap.sample-20.pb.gz
Serving web UI on http://localhost:9999
```

<img width="1011" height="919" alt="Screenshot 2026-01-15 at 12 08 28" src="https://github.com/user-attachments/assets/925f74e5-0b09-45cf-9dbf-3066421114b8" />

The good news is that I couldn’t reproduce this behavior in release `1.29.0-alpha.0`.