### PR TITLE
Testing 1.28 with cherry-pick af92e20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BASE_IMAGE_TAG ?= 1.28.2
 GIT_REVISION ?= release-1.28
 
 NEW_IMAGE_REGISTRY ?= ghcr.io/h0tbird
-NEW_IMAGE_TAG ?= 1.28.2-patch.2
+NEW_IMAGE_TAG ?= 1.28.2-patch.3
 
 MESHLAB_PATH ?= ~/git/h0tbird/meshlab
 ISTIO_PATH ?= ~/git/h0tbird/forked-istio

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -28,7 +28,7 @@ OTEL_COLLECTOR_CHART_VERSION='0.143.0'        # https://artifacthub.io/packages/
 VAULT_CHART_VERSION='0.31.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
 CERT_MANAGER_CHART_VERSION='v1.19.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
 KUBERNETES_REPLICATOR_CHART_VERSION='2.12.2'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
-ISTIO_CHART_VERSION='1.29.0-alpha.0'          # https://artifacthub.io/packages/helm/istio-official/base
+ISTIO_CHART_VERSION='1.28.2'                  # https://artifacthub.io/packages/helm/istio-official/base
 KIALI_CHART_VERSION='2.20.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
 
 #------------------------------------------------------------------------------

--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -28,7 +28,7 @@ spec:
             revision: {{ .Values.chartVersion | replace "." "-" }}
             revisionTags: [ "stable", "canary" ]
             pilot:
-            # image: ghcr.io/h0tbird/pilot:1.28.2-patch.1
+              image: ghcr.io/h0tbird/pilot:1.28.2-patch.2
               autoscaleEnabled: false
               env:
                 AUTO_RELOAD_PLUGIN_CERTS: true
@@ -37,9 +37,9 @@ spec:
                 ISTIOD_CUSTOM_HOST: {{`'istiod.{{name}}'`}}
                 ENABLE_NATIVE_SIDECARS: true
             global:
-            # hub: ghcr.io/h0tbird
-            # tag: 1.28.2-patch.1
-            # variant: ""
+              hub: ghcr.io/h0tbird
+              tag: 1.28.2-patch.2
+              variant: ""
               meshID: {{`'{{metadata.labels.cell}}'`}}
               network: {{`'{{metadata.labels.cell}}'`}}
               logAsJson: true

--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -28,7 +28,7 @@ spec:
             revision: {{ .Values.chartVersion | replace "." "-" }}
             revisionTags: [ "stable", "canary" ]
             pilot:
-              image: ghcr.io/h0tbird/pilot:1.28.2-patch.2
+              image: ghcr.io/h0tbird/pilot:1.28.2-patch.3
               autoscaleEnabled: false
               env:
                 AUTO_RELOAD_PLUGIN_CERTS: true
@@ -38,7 +38,7 @@ spec:
                 ENABLE_NATIVE_SIDECARS: true
             global:
               hub: ghcr.io/h0tbird
-              tag: 1.28.2-patch.2
+              tag: 1.28.2-patch.3
               variant: ""
               meshID: {{`'{{metadata.labels.cell}}'`}}
               network: {{`'{{metadata.labels.cell}}'`}}


### PR DESCRIPTION
Switched to `ghcr.io/h0tbird/pilot:1.28.2-patch.2`, which includes a cherry-pick of https://github.com/istio/istio/commit/af92e20c9c81c961bb16328d4fe673f74c4c3435