### PR TITLE
Bump to 1.29.0-alpha.0

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -16,7 +16,7 @@ allow_k8s_contexts([
 #------------------------------------------------------------------------------
 
 istio_version = '1-29-0-alpha-0'
-istio_dotted = istio_version.replace('-', '.')
+istio_dotted = '1.29.0-alpha.0'
 image_ref = 'pilot-discovery-dev'
 cluster_name = k8s_context().removeprefix('kind-')
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -15,7 +15,7 @@ allow_k8s_contexts([
 # Variables
 #------------------------------------------------------------------------------
 
-istio_version = '1-28-2'
+istio_version = '1-29-0-alpha-0'
 istio_dotted = istio_version.replace('-', '.')
 image_ref = 'pilot-discovery-dev'
 cluster_name = k8s_context().removeprefix('kind-')
@@ -165,11 +165,6 @@ spec:
           value: "false"
         - name: CLUSTER_ID
           value: {cluster_name}
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.memory
         - name: GOMAXPROCS
           valueFrom:
             resourceFieldRef:

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -28,7 +28,7 @@ OTEL_COLLECTOR_CHART_VERSION='0.143.0'        # https://artifacthub.io/packages/
 VAULT_CHART_VERSION='0.32.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
 CERT_MANAGER_CHART_VERSION='v1.19.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
 KUBERNETES_REPLICATOR_CHART_VERSION='2.12.2'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
-ISTIO_CHART_VERSION='1.28.2'                  # https://artifacthub.io/packages/helm/istio-official/base
+ISTIO_CHART_VERSION='1.29.0-alpha.0'          # https://artifacthub.io/packages/helm/istio-official/base
 KIALI_CHART_VERSION='2.20.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
```console
$ meshlab git:(my-first-bisect) meshlab run install-applicationsets

───[ ApplicationSets ]──────────────────────────────────────────────────

appproject.argoproj.io/cilium unchanged
applicationset.argoproj.io/cilium unchanged
appproject.argoproj.io/monitoring unchanged
applicationset.argoproj.io/prometheus unchanged
appproject.argoproj.io/monitoring unchanged
applicationset.argoproj.io/grafana unchanged
appproject.argoproj.io/monitoring unchanged
applicationset.argoproj.io/otelco-cluster unchanged
applicationset.argoproj.io/otelco-node unchanged
appproject.argoproj.io/vault unchanged
applicationset.argoproj.io/vault unchanged
appproject.argoproj.io/cert-manager unchanged
applicationset.argoproj.io/cert-manager unchanged
appproject.argoproj.io/kubernetes-replicator unchanged
applicationset.argoproj.io/kubernetes-replicator unchanged
appproject.argoproj.io/istio unchanged
applicationset.argoproj.io/istio-base configured
applicationset.argoproj.io/istio-cni configured
applicationset.argoproj.io/istio-ewgw configured
applicationset.argoproj.io/istio-issuers unchanged
applicationset.argoproj.io/istio-istiod configured
applicationset.argoproj.io/istio-nsgw configured
applicationset.argoproj.io/istio-ztunnel configured
appproject.argoproj.io/monitoring unchanged
applicationset.argoproj.io/kiali-operator unchanged
```