### PR TITLE
Use 1.28.3-patch.1-dev

### DIFF
--- a/bin/meshlab
+++ b/bin/meshlab
@@ -28,7 +28,7 @@ OTEL_COLLECTOR_CHART_VERSION='0.143.0'        # https://artifacthub.io/packages/
 VAULT_CHART_VERSION='0.32.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
 CERT_MANAGER_CHART_VERSION='v1.19.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
 KUBERNETES_REPLICATOR_CHART_VERSION='2.12.2'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
-ISTIO_CHART_VERSION='1.28.3'                  # https://artifacthub.io/packages/helm/istio-official/base
+ISTIO_CHART_VERSION='1.28.3-patch-1-dev'      # https://artifacthub.io/packages/helm/istio-official/base
 KIALI_CHART_VERSION='2.20.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
 
 #------------------------------------------------------------------------------

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -28,7 +28,7 @@ OTEL_COLLECTOR_CHART_VERSION='0.143.0'        # https://artifacthub.io/packages/
 VAULT_CHART_VERSION='0.32.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
 CERT_MANAGER_CHART_VERSION='v1.19.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
 KUBERNETES_REPLICATOR_CHART_VERSION='2.12.2'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
-ISTIO_CHART_VERSION='1.28.3-patch-1-dev'      # https://artifacthub.io/packages/helm/istio-official/base
+ISTIO_CHART_VERSION='1.28.3-patch.1-dev'      # https://artifacthub.io/packages/helm/istio-official/base
 KIALI_CHART_VERSION='2.20.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
 
 #------------------------------------------------------------------------------

--- a/charts/istio/templates/applicationsets/istio-base.yaml
+++ b/charts/istio/templates/applicationsets/istio-base.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       project: istio
       source:
-        repoURL: https://istio-release.storage.googleapis.com/charts
+        repoURL: https://h0tbird.github.io/forked-istio
         targetRevision: {{ .Values.chartVersion }}
         chart: base
         helm:

--- a/charts/istio/templates/applicationsets/istio-cni.yaml
+++ b/charts/istio/templates/applicationsets/istio-cni.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       project: istio
       source:
-        repoURL: https://istio-release.storage.googleapis.com/charts
+        repoURL: https://h0tbird.github.io/forked-istio
         targetRevision: {{ .Values.chartVersion }}
         chart: cni
         helm:

--- a/charts/istio/templates/applicationsets/istio-ewgw.yaml
+++ b/charts/istio/templates/applicationsets/istio-ewgw.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       project: istio
       source:
-        repoURL: https://istio-release.storage.googleapis.com/charts
+        repoURL: https://h0tbird.github.io/forked-istio
         targetRevision: {{ .Values.chartVersion }}
         chart: gateway
         helm:

--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       project: istio
       source:
-        repoURL: https://istio-release.storage.googleapis.com/charts
+        repoURL: https://h0tbird.github.io/forked-istio
         targetRevision: {{ .Values.chartVersion }}
         chart: istiod
         helm:
@@ -28,7 +28,7 @@ spec:
             revision: {{ .Values.chartVersion | replace "." "-" }}
             revisionTags: [ "stable", "canary" ]
             pilot:
-            # image: ghcr.io/h0tbird/pilot:1.28.3-patch.1-dev
+              image: ghcr.io/h0tbird/pilot:1.28.3-patch.1-dev
               autoscaleEnabled: false
               env:
                 AUTO_RELOAD_PLUGIN_CERTS: true
@@ -37,9 +37,9 @@ spec:
                 ISTIOD_CUSTOM_HOST: {{`'istiod.{{name}}'`}}
                 ENABLE_NATIVE_SIDECARS: true
             global:
-            # hub: ghcr.io/h0tbird
-            # tag: 1.28.3-patch.1-dev
-            # variant: ""
+              hub: ghcr.io/h0tbird
+              tag: 1.28.3-patch.1-dev
+              variant: ""
               meshID: {{`'{{metadata.labels.cell}}'`}}
               network: {{`'{{metadata.labels.cell}}'`}}
               logAsJson: true

--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -28,7 +28,7 @@ spec:
             revision: {{ .Values.chartVersion | replace "." "-" }}
             revisionTags: [ "stable", "canary" ]
             pilot:
-            # image: ghcr.io/h0tbird/pilot:1.28.2-patch.1
+              image: ghcr.io/h0tbird/pilot:1.28.3-patch.1-dev
               autoscaleEnabled: false
               env:
                 AUTO_RELOAD_PLUGIN_CERTS: true
@@ -37,8 +37,8 @@ spec:
                 ISTIOD_CUSTOM_HOST: {{`'istiod.{{name}}'`}}
                 ENABLE_NATIVE_SIDECARS: true
             global:
-            # hub: ghcr.io/h0tbird
-            # tag: 1.28.2-patch.1
+              hub: ghcr.io/h0tbird
+              tag: 1.28.3-patch.1-dev
               variant: "debug"
               meshID: {{`'{{metadata.labels.cell}}'`}}
               network: {{`'{{metadata.labels.cell}}'`}}

--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -39,7 +39,7 @@ spec:
             global:
               hub: ghcr.io/h0tbird
               tag: 1.28.3-patch.1-dev
-              variant: "debug"
+              variant: ""
               meshID: {{`'{{metadata.labels.cell}}'`}}
               network: {{`'{{metadata.labels.cell}}'`}}
               logAsJson: true

--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -28,7 +28,7 @@ spec:
             revision: {{ .Values.chartVersion | replace "." "-" }}
             revisionTags: [ "stable", "canary" ]
             pilot:
-              image: ghcr.io/h0tbird/pilot:1.28.3-patch.1-dev
+            # image: ghcr.io/h0tbird/pilot:1.28.3-patch.1-dev
               autoscaleEnabled: false
               env:
                 AUTO_RELOAD_PLUGIN_CERTS: true
@@ -37,9 +37,9 @@ spec:
                 ISTIOD_CUSTOM_HOST: {{`'istiod.{{name}}'`}}
                 ENABLE_NATIVE_SIDECARS: true
             global:
-              hub: ghcr.io/h0tbird
-              tag: 1.28.3-patch.1-dev
-              variant: ""
+            # hub: ghcr.io/h0tbird
+            # tag: 1.28.3-patch.1-dev
+            # variant: ""
               meshID: {{`'{{metadata.labels.cell}}'`}}
               network: {{`'{{metadata.labels.cell}}'`}}
               logAsJson: true

--- a/charts/istio/templates/applicationsets/istio-nsgw.yaml
+++ b/charts/istio/templates/applicationsets/istio-nsgw.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       project: istio
       sources:
-      - repoURL: https://istio-release.storage.googleapis.com/charts
+      - repoURL: https://h0tbird.github.io/forked-istio
         targetRevision: {{ .Values.chartVersion }}
         chart: gateway
         helm:

--- a/charts/istio/templates/applicationsets/istio-ztunnel.yaml
+++ b/charts/istio/templates/applicationsets/istio-ztunnel.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       project: istio
       source:
-        repoURL: https://istio-release.storage.googleapis.com/charts
+        repoURL: https://h0tbird.github.io/forked-istio
         targetRevision: {{ .Values.chartVersion }}
         chart: ztunnel
         helm:


### PR DESCRIPTION
No leak detected:

<img width="1393" height="1240" alt="Screenshot 2026-01-21 at 14 09 00" src="https://github.com/user-attachments/assets/a494e364-f653-4fd0-a883-494c02e6d63e" />
