### PR TITLE
Simplify cell/cluster iteration helpers

### DIFF
--- a/bin/meshlab
+++ b/bin/meshlab
@@ -54,7 +54,7 @@ cleanup() {
   pkill -f 'socat TCP-LISTEN:[0-9]+,fork TCP:' 2>/dev/null || true
 
   # Only delete clusters we created
-  for CLUSTER in $(list clusters all "${WLCNT:-99}"); do
+  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT:-99}"); do
     kind delete cluster --name "${CLUSTER}" 2>/dev/null || true
   done
 
@@ -120,7 +120,7 @@ create-clusters() {
   [ -d ./tmp ] || mkdir -p ./tmp
 
   # Configure kind
-  for CELL in $(list cells all "${WLCNT}"); do
+  for CELL in mngr $(list cells wkld "${WLCNT}"); do
     cat <<- EOF > "./tmp/kind-${CELL}.yaml"
 		kind: Cluster
 		apiVersion: kind.x-k8s.io/v1alpha4
@@ -136,7 +136,7 @@ create-clusters() {
   done
 
   # Create the clusters
-  for CELL in $(list cells all "${WLCNT}"); do for CLUSTER in ${CELLS[${CELL}]}; do (
+  for CELL in mngr $(list cells wkld "${WLCNT}"); do for CLUSTER in ${CELLS[${CELL}]:-${MNGR}}; do (
     kind get clusters 2>/dev/null | grep -q "${CLUSTER}" || {
       kind create cluster --name "${CLUSTER}" --config "./tmp/kind-${CELL}.yaml" -q
     }
@@ -144,7 +144,7 @@ create-clusters() {
 
   # Get and display all the IPs
   ensure-ips
-  for CLUSTER in $(list clusters all "${WLCNT}"); do
+  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do
     echo "${CLUSTER} = ${IP[${CLUSTER}]}"
   done
 }; SECTIONS+=( create-clusters )
@@ -162,7 +162,7 @@ add-registries-to-containerd() {
   echo "ghcr.io   --> http://registry-ghcr.io:5000"
 
   # Configure containerd in all clusters
-  for CLUSTER in $(list clusters all "${WLCNT}"); do (
+  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do (
     docker exec -i "${CLUSTER}-control-plane" bash -c '
       mkdir -p /etc/containerd/certs.d/docker.io
       cat <<- EOF > /etc/containerd/certs.d/docker.io/hosts.toml
@@ -196,7 +196,7 @@ setup-kubeconfig() {
 
   # Setup an in-cluster reachable API server config
   cp -f ~/.kube/config ~/.kube/config.in-cluster
-  for CLUSTER in $(list clusters all "${WLCNT}"); do
+  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do
     echo "Server: https://${IP[${CLUSTER}]}:6443"
     kubectl --kubeconfig ~/.kube/config.in-cluster \
     config set-cluster "kind-${CLUSTER}" \
@@ -226,7 +226,7 @@ install-cilium() {
   ensure-ips # Ensure cluster IPs are initialized
 
   # Install the Cilium CNI
-  for CLUSTER in $(list clusters all "${WLCNT}"); do (
+  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do (
 
     # Return early if already running
     kubectl --context "kind-${CLUSTER}" -n kube-system \
@@ -284,7 +284,7 @@ install-clustermesh() {
 install-k8s-gateway() {
   blue "───[ k8s_gateway ]──────────────────────────────────────────────────────"
 
-  for CLUSTER in $(list clusters all "${WLCNT}"); do (
+  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do (
     retry helm --kube-context "kind-${CLUSTER}" \
       upgrade -i exdns k8s_gateway/k8s-gateway \
       --version "${K8S_GATEWAY_CHART_VERSION}" \
@@ -305,7 +305,7 @@ setup-coredns() {
   MNGR_EXDNS_IP=$(getExtIP "${MNGR}" kube-system exdns-k8s-gateway)
 
   # Configure CoreDNS
-  for CELL in $(list cells all "${WLCNT}"); do for CLUSTER in ${CELLS[${CELL}]}; do (
+  for CELL in mngr $(list cells wkld "${WLCNT}"); do for CLUSTER in ${CELLS[${CELL}]:-${MNGR}}; do (
 
     kubectl --context "kind-${CLUSTER}" -n kube-system create cm coredns \
     --dry-run=client -o yaml --from-literal=Corefile="
@@ -466,7 +466,7 @@ bootstrap-dag() {
    --dry-run=client -o yaml | k0 -n argocd apply -f -
 
   # Create the monitoring namespace on all clusters
-  for CLUSTER in $(list clusters all "${WLCNT}"); do (
+  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do (
     kubectl --context "kind-${CLUSTER}" create ns monitoring \
     --dry-run=client -o yaml | kubectl --context "kind-${CLUSTER}" apply -f -
   ) & done; join

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -46,7 +46,7 @@ cleanup() {
   argocd context --delete "${MNGR}" 2>/dev/null || true
 
   # Only kill tilt instances we started (one per workload cluster)
-  for CLUSTER in $(list clusters wkld "${WLCNT:-99}"); do
+  for CLUSTER in $(clusters); do
     pkill -f "tilt up --context kind-${CLUSTER}" 2>/dev/null || true
   done
 
@@ -54,7 +54,7 @@ cleanup() {
   pkill -f 'socat TCP-LISTEN:[0-9]+,fork TCP:' 2>/dev/null || true
 
   # Only delete clusters we created
-  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT:-99}"); do
+  for CLUSTER in ${MNGR} $(clusters); do
     kind delete cluster --name "${CLUSTER}" 2>/dev/null || true
   done
 
@@ -120,7 +120,7 @@ create-clusters() {
   [ -d ./tmp ] || mkdir -p ./tmp
 
   # Configure kind
-  for CELL in mngr $(list cells wkld "${WLCNT}"); do
+  for CELL in mngr $(cells); do
     cat <<- EOF > "./tmp/kind-${CELL}.yaml"
 		kind: Cluster
 		apiVersion: kind.x-k8s.io/v1alpha4
@@ -136,7 +136,7 @@ create-clusters() {
   done
 
   # Create the clusters
-  for CELL in mngr $(list cells wkld "${WLCNT}"); do for CLUSTER in ${CELLS[${CELL}]:-${MNGR}}; do (
+  for CELL in mngr $(cells); do for CLUSTER in ${CELLS[${CELL}]:-${MNGR}}; do (
     kind get clusters 2>/dev/null | grep -q "${CLUSTER}" || {
       kind create cluster --name "${CLUSTER}" --config "./tmp/kind-${CELL}.yaml" -q
     }
@@ -144,7 +144,7 @@ create-clusters() {
 
   # Get and display all the IPs
   ensure-ips
-  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do
+  for CLUSTER in ${MNGR} $(clusters); do
     echo "${CLUSTER} = ${IP[${CLUSTER}]}"
   done
 }; SECTIONS+=( create-clusters )
@@ -162,7 +162,7 @@ add-registries-to-containerd() {
   echo "ghcr.io   --> http://registry-ghcr.io:5000"
 
   # Configure containerd in all clusters
-  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do (
+  for CLUSTER in ${MNGR} $(clusters); do (
     docker exec -i "${CLUSTER}-control-plane" bash -c '
       mkdir -p /etc/containerd/certs.d/docker.io
       cat <<- EOF > /etc/containerd/certs.d/docker.io/hosts.toml
@@ -196,7 +196,7 @@ setup-kubeconfig() {
 
   # Setup an in-cluster reachable API server config
   cp -f ~/.kube/config ~/.kube/config.in-cluster
-  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do
+  for CLUSTER in ${MNGR} $(clusters); do
     echo "Server: https://${IP[${CLUSTER}]}:6443"
     kubectl --kubeconfig ~/.kube/config.in-cluster \
     config set-cluster "kind-${CLUSTER}" \
@@ -226,7 +226,7 @@ install-cilium() {
   ensure-ips # Ensure cluster IPs are initialized
 
   # Install the Cilium CNI
-  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do (
+  for CLUSTER in ${MNGR} $(clusters); do (
 
     # Return early if already running
     kubectl --context "kind-${CLUSTER}" -n kube-system \
@@ -248,7 +248,7 @@ install-cilium() {
 install-clustermesh() {
   blue "───[ ClusterMesh ]──────────────────────────────────────────────────────"
 
-  for CELL in $(list cells wkld "${WLCNT}"); do (
+  for CELL in $(cells); do (
 
     # Get the clusters of the cell
     IFS=" " read -r -a CLUSTERS <<< "${CELLS[${CELL}]}"
@@ -284,7 +284,7 @@ install-clustermesh() {
 install-k8s-gateway() {
   blue "───[ k8s_gateway ]──────────────────────────────────────────────────────"
 
-  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do (
+  for CLUSTER in ${MNGR} $(clusters); do (
     retry helm --kube-context "kind-${CLUSTER}" \
       upgrade -i exdns k8s_gateway/k8s-gateway \
       --version "${K8S_GATEWAY_CHART_VERSION}" \
@@ -305,7 +305,7 @@ setup-coredns() {
   MNGR_EXDNS_IP=$(getExtIP "${MNGR}" kube-system exdns-k8s-gateway)
 
   # Configure CoreDNS
-  for CELL in mngr $(list cells wkld "${WLCNT}"); do for CLUSTER in ${CELLS[${CELL}]:-${MNGR}}; do (
+  for CELL in mngr $(cells); do for CLUSTER in ${CELLS[${CELL}]:-${MNGR}}; do (
 
     kubectl --context "kind-${CLUSTER}" -n kube-system create cm coredns \
     --dry-run=client -o yaml --from-literal=Corefile="
@@ -391,7 +391,7 @@ register-argocd-clusters() {
       --password "${PASS}"
 
     # Add clusters with labels
-    for CELL in $(list cells wkld "${WLCNT}"); do for CLUSTER in ${CELLS[${CELL}]}; do
+    for CELL in $(cells); do for CLUSTER in ${CELLS[${CELL}]}; do
       argocd cluster list | grep -q "${CLUSTER}" || \
       argocd cluster add -y "kind-${CLUSTER}" \
         --kubeconfig ~/.kube/config.in-cluster \
@@ -466,7 +466,7 @@ bootstrap-dag() {
    --dry-run=client -o yaml | k0 -n argocd apply -f -
 
   # Create the monitoring namespace on all clusters
-  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do (
+  for CLUSTER in ${MNGR} $(clusters); do (
     kubectl --context "kind-${CLUSTER}" create ns monitoring \
     --dry-run=client -o yaml | kubectl --context "kind-${CLUSTER}" apply -f -
   ) & done; join
@@ -649,7 +649,7 @@ bootstrap-dag() {
 istio-endpoint-discovery() {
   blue "───[ Istio remote secrets ]─────────────────────────────────────────────"
 
-  for CELL in $(list cells wkld "${WLCNT}"); do (
+  for CELL in $(cells); do (
     IFS=" " read -r -a CLUSTERS <<< "${CELLS[${CELL}]}"
     istioctl --kubeconfig ~/.kube/config.in-cluster create-remote-secret \
       --context "kind-${CLUSTERS[0]}" --name="${CLUSTERS[0]}" | \
@@ -729,7 +729,7 @@ kiali-multicluster() {
   blue "───[ External kiali multi-cluster setup ]───────────────────────────────"
   ensure-ips # Ensure cluster IPs are initialized
 
-  for CLUSTER in $(list clusters wkld "${WLCNT}"); do
+  for CLUSTER in $(clusters); do
     retry kiali-prepare-remote-cluster.sh \
       --kiali-cluster-context "kind-${MNGR}" \
       --remote-cluster-context "kind-${CLUSTER}" \
@@ -762,7 +762,7 @@ tilt-up() {
   export TILT_DISABLE_ANALYTICS=1
 
   # Start tilt for each workload cluster
-  PORT=9091; for CLUSTER in $(list clusters wkld "${WLCNT}"); do
+  PORT=9091; for CLUSTER in $(clusters); do
     if pgrep -f "tilt up --context kind-${CLUSTER}" &>/dev/null; then
       echo "tilt ${CLUSTER} on port ${PORT} (running)"
     else
@@ -807,10 +807,10 @@ publish-ports() {
 #------------------------------------------------------------------------------
 
 case "${1:-}" in
-  create) WLCNT="${2:-1}" ;;
+  create) export WLCNT="${2:-1}" ;;
   delete) cleanup; exit 0 ;;
   watch) watch --color 'ml short'; exit 0 ;;
-  run)  WLCNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
+  run)  export WLCNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
   list) printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;
   *)    echo "Usage: $(basename "$0") <create|delete|watch|list|run SECTION [count]>"; exit 1 ;;
 esac

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -136,7 +136,7 @@ create-clusters() {
   done
 
   # Create the clusters
-  for CELL in mngr $(cells); do for CLUSTER in ${CELLS[${CELL}]:-${MNGR}}; do (
+  for CELL in mngr $(cells); do for CLUSTER in $(clusters_of "${CELL}"); do (
     kind get clusters 2>/dev/null | grep -q "${CLUSTER}" || {
       kind create cluster --name "${CLUSTER}" --config "./tmp/kind-${CELL}.yaml" -q
     }
@@ -305,7 +305,7 @@ setup-coredns() {
   MNGR_EXDNS_IP=$(getExtIP "${MNGR}" kube-system exdns-k8s-gateway)
 
   # Configure CoreDNS
-  for CELL in mngr $(cells); do for CLUSTER in ${CELLS[${CELL}]:-${MNGR}}; do (
+  for CELL in mngr $(cells); do for CLUSTER in $(clusters_of "${CELL}"); do (
 
     kubectl --context "kind-${CLUSTER}" -n kube-system create cm coredns \
     --dry-run=client -o yaml --from-literal=Corefile="
@@ -391,7 +391,7 @@ register-argocd-clusters() {
       --password "${PASS}"
 
     # Add clusters with labels
-    for CELL in $(cells); do for CLUSTER in ${CELLS[${CELL}]}; do
+    for CELL in $(cells); do for CLUSTER in $(clusters_of "${CELL}"); do
       argocd cluster list | grep -q "${CLUSTER}" || \
       argocd cluster add -y "kind-${CLUSTER}" \
         --kubeconfig ~/.kube/config.in-cluster \

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -54,7 +54,7 @@ cleanup() {
   pkill -f 'socat TCP-LISTEN:[0-9]+,fork TCP:' 2>/dev/null || true
 
   # Only delete clusters we created
-  for CLUSTER in ${MNGR} $(clusters); do
+  for CLUSTER in $(all_clusters); do
     kind delete cluster --name "${CLUSTER}" 2>/dev/null || true
   done
 
@@ -144,7 +144,7 @@ create-clusters() {
 
   # Get and display all the IPs
   ensure-ips
-  for CLUSTER in ${MNGR} $(clusters); do
+  for CLUSTER in $(all_clusters); do
     echo "${CLUSTER} = ${IP[${CLUSTER}]}"
   done
 }; SECTIONS+=( create-clusters )
@@ -162,7 +162,7 @@ add-registries-to-containerd() {
   echo "ghcr.io   --> http://registry-ghcr.io:5000"
 
   # Configure containerd in all clusters
-  for CLUSTER in ${MNGR} $(clusters); do (
+  for CLUSTER in $(all_clusters); do (
     docker exec -i "${CLUSTER}-control-plane" bash -c '
       mkdir -p /etc/containerd/certs.d/docker.io
       cat <<- EOF > /etc/containerd/certs.d/docker.io/hosts.toml
@@ -196,7 +196,7 @@ setup-kubeconfig() {
 
   # Setup an in-cluster reachable API server config
   cp -f ~/.kube/config ~/.kube/config.in-cluster
-  for CLUSTER in ${MNGR} $(clusters); do
+  for CLUSTER in $(all_clusters); do
     echo "Server: https://${IP[${CLUSTER}]}:6443"
     kubectl --kubeconfig ~/.kube/config.in-cluster \
     config set-cluster "kind-${CLUSTER}" \
@@ -226,7 +226,7 @@ install-cilium() {
   ensure-ips # Ensure cluster IPs are initialized
 
   # Install the Cilium CNI
-  for CLUSTER in ${MNGR} $(clusters); do (
+  for CLUSTER in $(all_clusters); do (
 
     # Return early if already running
     kubectl --context "kind-${CLUSTER}" -n kube-system \
@@ -284,7 +284,7 @@ install-clustermesh() {
 install-k8s-gateway() {
   blue "───[ k8s_gateway ]──────────────────────────────────────────────────────"
 
-  for CLUSTER in ${MNGR} $(clusters); do (
+  for CLUSTER in $(all_clusters); do (
     retry helm --kube-context "kind-${CLUSTER}" \
       upgrade -i exdns k8s_gateway/k8s-gateway \
       --version "${K8S_GATEWAY_CHART_VERSION}" \
@@ -466,7 +466,7 @@ bootstrap-dag() {
    --dry-run=client -o yaml | k0 -n argocd apply -f -
 
   # Create the monitoring namespace on all clusters
-  for CLUSTER in ${MNGR} $(clusters); do (
+  for CLUSTER in $(all_clusters); do (
     kubectl --context "kind-${CLUSTER}" create ns monitoring \
     --dry-run=client -o yaml | kubectl --context "kind-${CLUSTER}" apply -f -
   ) & done; join

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -120,7 +120,7 @@ create-clusters() {
   [ -d ./tmp ] || mkdir -p ./tmp
 
   # Configure kind
-  for CELL in mngr $(cells); do
+  for CELL in $(all_cells); do
     cat <<- EOF > "./tmp/kind-${CELL}.yaml"
 		kind: Cluster
 		apiVersion: kind.x-k8s.io/v1alpha4
@@ -136,11 +136,11 @@ create-clusters() {
   done
 
   # Create the clusters
-  for CELL in mngr $(cells); do for CLUSTER in $(clusters_of "${CELL}"); do (
+  for CLUSTER in $(all_clusters); do (
     kind get clusters 2>/dev/null | grep -q "${CLUSTER}" || {
-      kind create cluster --name "${CLUSTER}" --config "./tmp/kind-${CELL}.yaml" -q
+      kind create cluster --name "${CLUSTER}" --config "./tmp/kind-${CELL_OF[${CLUSTER}]}.yaml" -q
     }
-  ) & done; done; join
+  ) & done; join
 
   # Get and display all the IPs
   ensure-ips
@@ -305,7 +305,8 @@ setup-coredns() {
   MNGR_EXDNS_IP=$(getExtIP "${MNGR}" kube-system exdns-k8s-gateway)
 
   # Configure CoreDNS
-  for CELL in mngr $(cells); do for CLUSTER in $(clusters_of "${CELL}"); do (
+  for CLUSTER in $(all_clusters); do (
+    CELL=${CELL_OF[${CLUSTER}]}
 
     kubectl --context "kind-${CLUSTER}" -n kube-system create cm coredns \
     --dry-run=client -o yaml --from-literal=Corefile="
@@ -339,7 +340,7 @@ setup-coredns() {
     # Restart otherwise it takes a while to pick up the new config
     kubectl --context "kind-${CLUSTER}" -n kube-system rollout restart deployment coredns
 
-  ) & done; done; join
+  ) & done; join
 }; SECTIONS+=( setup-coredns )
 
 #------------------------------------------------------------------------------
@@ -391,7 +392,8 @@ register-argocd-clusters() {
       --password "${PASS}"
 
     # Add clusters with labels
-    for CELL in $(cells); do for CLUSTER in $(clusters_of "${CELL}"); do
+    for CLUSTER in $(clusters); do
+      CELL=${CELL_OF[${CLUSTER}]}
       argocd cluster list | grep -q "${CLUSTER}" || \
       argocd cluster add -y "kind-${CLUSTER}" \
         --kubeconfig ~/.kube/config.in-cluster \
@@ -399,7 +401,7 @@ register-argocd-clusters() {
         --label name="${CLUSTER}" \
         --label cell="${CELL}" \
         --logformat text
-    done; done
+    done
   }
 }; SECTIONS+=( register-argocd-clusters )
 

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -46,16 +46,16 @@ cleanup() {
   argocd context --delete "${MNGR}" 2>/dev/null || true
 
   # Only kill tilt instances we started (one per workload cluster)
-  for CLUSTER in $(clusters); do
-    pkill -f "tilt up --context kind-${CLUSTER}" 2>/dev/null || true
+  for cluster in $(clusters); do
+    pkill -f "tilt up --context kind-${cluster}" 2>/dev/null || true
   done
 
   # Only kill socat tunnels we started from publish()
   pkill -f 'socat TCP-LISTEN:[0-9]+,fork TCP:' 2>/dev/null || true
 
   # Only delete clusters we created
-  for CLUSTER in $(all_clusters); do
-    kind delete cluster --name "${CLUSTER}" 2>/dev/null || true
+  for cluster in $(all_clusters); do
+    kind delete cluster --name "${cluster}" 2>/dev/null || true
   done
 
   rm -rf ./tmp/*
@@ -120,8 +120,8 @@ create-clusters() {
   [ -d ./tmp ] || mkdir -p ./tmp
 
   # Configure kind
-  for CELL in $(all_cells); do
-    cat <<- EOF > "./tmp/kind-${CELL}.yaml"
+  for cell in $(all_cells); do
+    cat <<- EOF > "./tmp/kind-${cell}.yaml"
 		kind: Cluster
 		apiVersion: kind.x-k8s.io/v1alpha4
 		networking:
@@ -131,21 +131,21 @@ create-clusters() {
 		  - |-
 		    kind: ClusterConfiguration
 		    networking:
-		      dnsDomain: "${CELL}.local"
+		      dnsDomain: "${cell}.local"
 		EOF
   done
 
   # Create the clusters
-  for CLUSTER in $(all_clusters); do (
-    kind get clusters 2>/dev/null | grep -q "${CLUSTER}" || {
-      kind create cluster --name "${CLUSTER}" --config "./tmp/kind-${CELL_OF[${CLUSTER}]}.yaml" -q
+  for cluster in $(all_clusters); do (
+    kind get clusters 2>/dev/null | grep -q "${cluster}" || {
+      kind create cluster --name "${cluster}" --config "./tmp/kind-${CELL_OF[${cluster}]}.yaml" -q
     }
   ) & done; join
 
   # Get and display all the IPs
   ensure-ips
-  for CLUSTER in $(all_clusters); do
-    echo "${CLUSTER} = ${IP[${CLUSTER}]}"
+  for cluster in $(all_clusters); do
+    echo "${cluster} = ${IP[${cluster}]}"
   done
 }; SECTIONS+=( create-clusters )
 
@@ -162,8 +162,8 @@ add-registries-to-containerd() {
   echo "ghcr.io   --> http://registry-ghcr.io:5000"
 
   # Configure containerd in all clusters
-  for CLUSTER in $(all_clusters); do (
-    docker exec -i "${CLUSTER}-control-plane" bash -c '
+  for cluster in $(all_clusters); do (
+    docker exec -i "${cluster}-control-plane" bash -c '
       mkdir -p /etc/containerd/certs.d/docker.io
       cat <<- EOF > /etc/containerd/certs.d/docker.io/hosts.toml
 			server = "https://registry-1.docker.io"
@@ -196,11 +196,11 @@ setup-kubeconfig() {
 
   # Setup an in-cluster reachable API server config
   cp -f ~/.kube/config ~/.kube/config.in-cluster
-  for CLUSTER in $(all_clusters); do
-    echo "Server: https://${IP[${CLUSTER}]}:6443"
+  for cluster in $(all_clusters); do
+    echo "Server: https://${IP[${cluster}]}:6443"
     kubectl --kubeconfig ~/.kube/config.in-cluster \
-    config set-cluster "kind-${CLUSTER}" \
-    --server="https://${IP[${CLUSTER}]}:6443"
+    config set-cluster "kind-${cluster}" \
+    --server="https://${IP[${cluster}]}:6443"
   done
 }; SECTIONS+=( setup-kubeconfig )
 
@@ -226,18 +226,18 @@ install-cilium() {
   ensure-ips # Ensure cluster IPs are initialized
 
   # Install the Cilium CNI
-  for CLUSTER in $(all_clusters); do (
+  for cluster in $(all_clusters); do (
 
     # Return early if already running
-    kubectl --context "kind-${CLUSTER}" -n kube-system \
+    kubectl --context "kind-${cluster}" -n kube-system \
       get deploy cilium-operator 2>/dev/null && exit 0
 
     # Install
-    cilium install --context "kind-${CLUSTER}" --wait \
+    cilium install --context "kind-${cluster}" --wait \
       --version "v${CILIUM_CHART_VERSION}" \
       --values ./charts/cilium/values.yaml \
-      --values ./charts/cilium/values/"${CLUSTER}".yaml \
-      --set k8sServiceHost="${IP[${CLUSTER}]}"
+      --values ./charts/cilium/values/"${cluster}".yaml \
+      --set k8sServiceHost="${IP[${cluster}]}"
   ) & done; join
 }; SECTIONS+=( install-cilium )
 
@@ -248,10 +248,10 @@ install-cilium() {
 install-clustermesh() {
   blue "───[ ClusterMesh ]──────────────────────────────────────────────────────"
 
-  for CELL in $(cells); do (
+  for cell in $(cells); do (
 
     # Get the clusters of the cell
-    IFS=" " read -r -a CLUSTERS <<< "${CELLS[${CELL}]}"
+    IFS=" " read -r -a CLUSTERS <<< "${CELLS[${cell}]}"
 
     # Return early if already running
     kubectl --context "kind-${CLUSTERS[0]}" -n kube-system get deploy clustermesh-apiserver 2>/dev/null &&
@@ -284,8 +284,8 @@ install-clustermesh() {
 install-k8s-gateway() {
   blue "───[ k8s_gateway ]──────────────────────────────────────────────────────"
 
-  for CLUSTER in $(all_clusters); do (
-    retry helm --kube-context "kind-${CLUSTER}" \
+  for cluster in $(all_clusters); do (
+    retry helm --kube-context "kind-${cluster}" \
       upgrade -i exdns k8s_gateway/k8s-gateway \
       --version "${K8S_GATEWAY_CHART_VERSION}" \
       --namespace kube-system \
@@ -305,10 +305,10 @@ setup-coredns() {
   MNGR_EXDNS_IP=$(getExtIP "${MNGR}" kube-system exdns-k8s-gateway)
 
   # Configure CoreDNS
-  for CLUSTER in $(all_clusters); do (
-    CELL=${CELL_OF[${CLUSTER}]}
+  for cluster in $(all_clusters); do (
+    cell=${CELL_OF[${cluster}]}
 
-    kubectl --context "kind-${CLUSTER}" -n kube-system create cm coredns \
+    kubectl --context "kind-${cluster}" -n kube-system create cm coredns \
     --dry-run=client -o yaml --from-literal=Corefile="
     .:53 {
       errors
@@ -316,7 +316,7 @@ setup-coredns() {
          lameduck 5s
       }
       ready
-      kubernetes ${CELL}.local in-addr.arpa ip6.arpa {
+      kubernetes ${cell}.local in-addr.arpa ip6.arpa {
          pods insecure
          fallthrough in-addr.arpa ip6.arpa
          ttl 30
@@ -326,8 +326,8 @@ setup-coredns() {
          max_concurrent 1000
       }
       cache 30 {
-         disable success ${CELL}.local
-         disable denial ${CELL}.local
+         disable success ${cell}.local
+         disable denial ${cell}.local
       }
       loop
       reload
@@ -335,10 +335,10 @@ setup-coredns() {
     }
     ${DOMAIN}:53 {
       forward . ${MNGR_EXDNS_IP}
-    }" | kubectl --context "kind-${CLUSTER}" -n kube-system apply -f - 2>/dev/null
+    }" | kubectl --context "kind-${cluster}" -n kube-system apply -f - 2>/dev/null
 
     # Restart otherwise it takes a while to pick up the new config
-    kubectl --context "kind-${CLUSTER}" -n kube-system rollout restart deployment coredns
+    kubectl --context "kind-${cluster}" -n kube-system rollout restart deployment coredns
 
   ) & done; join
 }; SECTIONS+=( setup-coredns )
@@ -392,14 +392,14 @@ register-argocd-clusters() {
       --password "${PASS}"
 
     # Add clusters with labels
-    for CLUSTER in $(clusters); do
-      CELL=${CELL_OF[${CLUSTER}]}
-      argocd cluster list | grep -q "${CLUSTER}" || \
-      argocd cluster add -y "kind-${CLUSTER}" \
+    for cluster in $(clusters); do
+      cell=${CELL_OF[${cluster}]}
+      argocd cluster list | grep -q "${cluster}" || \
+      argocd cluster add -y "kind-${cluster}" \
         --kubeconfig ~/.kube/config.in-cluster \
-        --name "${CLUSTER}" \
-        --label name="${CLUSTER}" \
-        --label cell="${CELL}" \
+        --name "${cluster}" \
+        --label name="${cluster}" \
+        --label cell="${cell}" \
         --logformat text
     done
   }
@@ -468,9 +468,9 @@ bootstrap-dag() {
    --dry-run=client -o yaml | k0 -n argocd apply -f -
 
   # Create the monitoring namespace on all clusters
-  for CLUSTER in $(all_clusters); do (
-    kubectl --context "kind-${CLUSTER}" create ns monitoring \
-    --dry-run=client -o yaml | kubectl --context "kind-${CLUSTER}" apply -f -
+  for cluster in $(all_clusters); do (
+    kubectl --context "kind-${cluster}" create ns monitoring \
+    --dry-run=client -o yaml | kubectl --context "kind-${cluster}" apply -f -
   ) & done; join
 
   # Create the bootstrap workflow
@@ -651,8 +651,8 @@ bootstrap-dag() {
 istio-endpoint-discovery() {
   blue "───[ Istio remote secrets ]─────────────────────────────────────────────"
 
-  for CELL in $(cells); do (
-    IFS=" " read -r -a CLUSTERS <<< "${CELLS[${CELL}]}"
+  for cell in $(cells); do (
+    IFS=" " read -r -a CLUSTERS <<< "${CELLS[${cell}]}"
     istioctl --kubeconfig ~/.kube/config.in-cluster create-remote-secret \
       --context "kind-${CLUSTERS[0]}" --name="${CLUSTERS[0]}" | \
       kubectl --context "kind-${CLUSTERS[1]}" apply -f -
@@ -731,16 +731,16 @@ kiali-multicluster() {
   blue "───[ External kiali multi-cluster setup ]───────────────────────────────"
   ensure-ips # Ensure cluster IPs are initialized
 
-  for CLUSTER in $(clusters); do
+  for cluster in $(clusters); do
     retry kiali-prepare-remote-cluster.sh \
       --kiali-cluster-context "kind-${MNGR}" \
-      --remote-cluster-context "kind-${CLUSTER}" \
+      --remote-cluster-context "kind-${cluster}" \
       --view-only false \
       --process-kiali-secret true \
       --process-remote-resources true \
       --kiali-cluster-namespace monitoring \
-      --remote-cluster-name "${CLUSTER}" \
-      --remote-cluster-url "https://${IP[${CLUSTER}]}:6443" |
+      --remote-cluster-name "${cluster}" \
+      --remote-cluster-url "https://${IP[${cluster}]}:6443" |
       grep -v '^INFO:'
   done
 
@@ -764,13 +764,13 @@ tilt-up() {
   export TILT_DISABLE_ANALYTICS=1
 
   # Start tilt for each workload cluster
-  PORT=9091; for CLUSTER in $(clusters); do
-    if pgrep -f "tilt up --context kind-${CLUSTER}" &>/dev/null; then
-      echo "tilt ${CLUSTER} on port ${PORT} (running)"
+  PORT=9091; for cluster in $(clusters); do
+    if pgrep -f "tilt up --context kind-${cluster}" &>/dev/null; then
+      echo "tilt ${cluster} on port ${PORT} (running)"
     else
-      setsid tilt up --context "kind-${CLUSTER}" --port "${PORT}" \
-      &> "./tmp/tilt-${CLUSTER}.log" &
-      echo "tilt ${CLUSTER} on port ${PORT} (started)"
+      setsid tilt up --context "kind-${cluster}" --port "${PORT}" \
+      &> "./tmp/tilt-${cluster}.log" &
+      echo "tilt ${cluster} on port ${PORT} (started)"
     fi
     ((PORT++))
   done

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -33,8 +33,7 @@ function list {
 
   for CELL in "${!CELLS[@]}"; do
 
-    [[ "${2}" == "wkld" && "${CELL}" == "mngr" ]] && continue
-    [[ "${CELL}" != "mngr" ]] && ((count++))
+    ((count++))
     [[ "${limit}" -gt 0 && "${count}" -gt "${limit}" ]] && break
 
     case $1 in

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -15,15 +15,13 @@ declare -A CELLS=(
   [pizza]="pizza-1 pizza-2"
 )
 
-# Manager + workload cells (cell -> space-separated clusters)
-declare -A ALL_CELLS=( [mngr]="${MNGR}" )
-for _c in "${!CELLS[@]}"; do ALL_CELLS[${_c}]="${CELLS[${_c}]}"; done; unset _c
-
 # Reverse map (cluster -> cell), covers manager + all workload clusters
-declare -A CELL_OF
-for _c in "${!ALL_CELLS[@]}"; do
-  for _x in ${ALL_CELLS[${_c}]}; do CELL_OF[${_x}]=${_c}; done
-done; unset _c _x
+# shellcheck disable=SC2034 # used by bin/meshlab
+declare -A CELL_OF=(
+  [${MNGR}]=mngr
+  [pasta-1]=pasta [pasta-2]=pasta
+  [pizza-1]=pizza [pizza-2]=pizza
+)
 
 # Colors
 CYAN='\e[1;36m'

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -7,15 +7,13 @@
 export MNGR="mnger-1"
 export DOMAIN="demo.lab"
 export PASS='meshlab123'
+export SECTIONS=()
 
-# Define workload cells and their clusters (mngr is tracked separately via ${MNGR})
+# Define workload cells and their clusters
 declare -A CELLS=(
   [pasta]="pasta-1 pasta-2"
   [pizza]="pizza-1 pizza-2"
 )
-
-# Runnable sections (in order)
-export SECTIONS=()
 
 # Colors
 CYAN='\e[1;36m'
@@ -29,7 +27,7 @@ RST='\e[0m'
 function cells {
   local count=0
   for CELL in "${!CELLS[@]}"; do
-    ((++count > ${WLCNT:-99})) && break
+    ((++count > ${WLCNT:-1})) && break
     echo -n "${CELL} "
   done
 }
@@ -37,7 +35,7 @@ function cells {
 function clusters {
   local count=0
   for CELL in "${!CELLS[@]}"; do
-    ((++count > ${WLCNT:-99})) && break
+    ((++count > ${WLCNT:-1})) && break
     echo -n "${CELLS[${CELL}]} "
   done
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -23,25 +23,22 @@ DIM='\e[2m'
 RST='\e[0m'
 
 #------------------------------------------------------------------------------
-# List cells and clusters
+# List the first ${WLCNT} workload cells (or their clusters)
 #------------------------------------------------------------------------------
 
-function list {
-
+function cells {
   local count=0
-  local limit="${3:-0}"
-
   for CELL in "${!CELLS[@]}"; do
+    ((++count > ${WLCNT:-99})) && break
+    echo -n "${CELL} "
+  done
+}
 
-    ((count++))
-    [[ "${limit}" -gt 0 && "${count}" -gt "${limit}" ]] && break
-
-    case $1 in
-      "cells")
-        echo -n "${CELL} " ;;
-      "clusters")
-        echo -n "${CELLS[${CELL}]} " ;;
-    esac
+function clusters {
+  local count=0
+  for CELL in "${!CELLS[@]}"; do
+    ((++count > ${WLCNT:-99})) && break
+    echo -n "${CELLS[${CELL}]} "
   done
 }
 
@@ -184,7 +181,7 @@ declare -gxA IP; IP_INIT=false
 
 function ensure-ips {
   [[ "${IP_INIT}" == true ]] && return 0
-  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do
+  for CLUSTER in ${MNGR} $(clusters); do
     IP[${CLUSTER}]=$(docker inspect "${CLUSTER}-control-plane" |
       jq -r '.[].NetworkSettings.Networks.kind.IPAddress')
   done; IP_INIT=true

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -15,6 +15,16 @@ declare -A CELLS=(
   [pizza]="pizza-1 pizza-2"
 )
 
+# Manager + workload cells (cell -> space-separated clusters)
+declare -A ALL_CELLS=( [mngr]="${MNGR}" )
+for _c in "${!CELLS[@]}"; do ALL_CELLS[${_c}]="${CELLS[${_c}]}"; done; unset _c
+
+# Reverse map (cluster -> cell), covers manager + all workload clusters
+declare -A CELL_OF
+for _c in "${!ALL_CELLS[@]}"; do
+  for _x in ${ALL_CELLS[${_c}]}; do CELL_OF[${_x}]=${_c}; done
+done; unset _c _x
+
 # Colors
 CYAN='\e[1;36m'
 DIM='\e[2m'
@@ -40,14 +50,14 @@ function clusters {
   done
 }
 
+# Manager + first ${WLCNT} workload cells
+function all_cells {
+  echo "mngr $(cells)"
+}
+
 # Manager + workload clusters (the universe of kind clusters)
 function all_clusters {
   echo "${MNGR} $(clusters)"
-}
-
-# Clusters belonging to the given cell ("mngr" returns ${MNGR})
-function clusters_of {
-  echo "${CELLS[$1]:-${MNGR}}"
 }
 
 #------------------------------------------------------------------------------

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -35,9 +35,9 @@ RST='\e[0m'
 # List the first ${WLCNT} workload cells
 function cells {
   local count=0
-  for CELL in "${!CELLS[@]}"; do
+  for cell in "${!CELLS[@]}"; do
     ((++count > ${WLCNT:-1})) && break
-    echo -n "${CELL} "
+    echo -n "${cell} "
   done
 }
 
@@ -49,9 +49,9 @@ function all_cells {
 # List the first ${WLCNT} workload clusters
 function clusters {
   local count=0
-  for CELL in "${!CELLS[@]}"; do
+  for cell in "${!CELLS[@]}"; do
     ((++count > ${WLCNT:-1})) && break
-    echo -n "${CELLS[${CELL}]} "
+    echo -n "${CELLS[${cell}]} "
   done
 }
 
@@ -199,8 +199,8 @@ declare -gxA IP; IP_INIT=false
 
 function ensure-ips {
   [[ "${IP_INIT}" == true ]] && return 0
-  for CLUSTER in $(all_clusters); do
-    IP[${CLUSTER}]=$(docker inspect "${CLUSTER}-control-plane" |
+  for cluster in $(all_clusters); do
+    IP[${cluster}]=$(docker inspect "${cluster}-control-plane" |
       jq -r '.[].NetworkSettings.Networks.kind.IPAddress')
   done; IP_INIT=true
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -32,6 +32,7 @@ RST='\e[0m'
 # List the first ${WLCNT} workload cells (or their clusters)
 #------------------------------------------------------------------------------
 
+# List the first ${WLCNT} workload cells
 function cells {
   local count=0
   for CELL in "${!CELLS[@]}"; do
@@ -40,6 +41,12 @@ function cells {
   done
 }
 
+# Manager cell + workload cells above
+function all_cells {
+  echo "mngr $(cells)"
+}
+
+# List the first ${WLCNT} workload clusters
 function clusters {
   local count=0
   for CELL in "${!CELLS[@]}"; do
@@ -48,12 +55,7 @@ function clusters {
   done
 }
 
-# Manager + first ${WLCNT} workload cells
-function all_cells {
-  echo "mngr $(cells)"
-}
-
-# Manager + workload clusters (the universe of kind clusters)
+# Manager cluster + workload clusters above
 function all_clusters {
   echo "${MNGR} $(clusters)"
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -8,9 +8,8 @@ export MNGR="mnger-1"
 export DOMAIN="demo.lab"
 export PASS='meshlab123'
 
-# Define cells and clusters
+# Define workload cells and their clusters (mngr is tracked separately via ${MNGR})
 declare -A CELLS=(
-  [mngr]=${MNGR}
   [pasta]="pasta-1 pasta-2"
   [pizza]="pizza-1 pizza-2"
 )
@@ -186,7 +185,7 @@ declare -gxA IP; IP_INIT=false
 
 function ensure-ips {
   [[ "${IP_INIT}" == true ]] && return 0
-  for CLUSTER in $(list clusters all "${WLCNT}"); do
+  for CLUSTER in ${MNGR} $(list clusters wkld "${WLCNT}"); do
     IP[${CLUSTER}]=$(docker inspect "${CLUSTER}-control-plane" |
       jq -r '.[].NetworkSettings.Networks.kind.IPAddress')
   done; IP_INIT=true

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -40,6 +40,11 @@ function clusters {
   done
 }
 
+# Manager + workload clusters (the universe of kind clusters)
+function all_clusters {
+  echo "${MNGR} $(clusters)"
+}
+
 #------------------------------------------------------------------------------
 # Returns the CIDR for the given cluster
 #------------------------------------------------------------------------------
@@ -179,7 +184,7 @@ declare -gxA IP; IP_INIT=false
 
 function ensure-ips {
   [[ "${IP_INIT}" == true ]] && return 0
-  for CLUSTER in ${MNGR} $(clusters); do
+  for CLUSTER in $(all_clusters); do
     IP[${CLUSTER}]=$(docker inspect "${CLUSTER}-control-plane" |
       jq -r '.[].NetworkSettings.Networks.kind.IPAddress')
   done; IP_INIT=true

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -45,6 +45,11 @@ function all_clusters {
   echo "${MNGR} $(clusters)"
 }
 
+# Clusters belonging to the given cell ("mngr" returns ${MNGR})
+function clusters_of {
+  echo "${CELLS[$1]:-${MNGR}}"
+}
+
 #------------------------------------------------------------------------------
 # Returns the CIDR for the given cluster
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Refactors `lib/common.sh` so `mngr` is no longer modeled as a "cell", and the `list` helper loses its positional flags.

Done in small, individually-functional commits to keep the script working at every step.

### Phase 1 — Move `mngr` out of `CELLS`

- **1.1 (this commit)** — Drop `[mngr]=${MNGR}` from `CELLS`. Every call site that previously used `list ... all ...` to also yield the manager now explicitly prefixes `${MNGR}` (clusters) or `mngr` (cells). The `wkld`/`all` branches inside `list` produce identical output now and become dead code.
- **1.2 (next)** — Remove the dead `mngr`-skip and counter guard from `list`.

### Phase 2 — Rename `list`

- **2.1 (next)** — Replace `list` with two zero-arg helpers `cells` and `clusters` that read `${WLCNT:-99}` from the environment. Mechanical rewrite of all call sites.

### Verification (per commit)

- `bash -n lib/common.sh bin/meshlab`
- `shellcheck lib/common.sh bin/meshlab`
- Diff `list … all` output before/after — values match.
- Full smoke (`bin/meshlab create 1`) deferred to PR review.