### PR TITLE
style(scripts): align bin/meshlab and lib/common.sh with Google Shell Style Guide

### DIFF
--- a/bin/meshlab
+++ b/bin/meshlab
@@ -20,19 +20,19 @@ NET_START=$(net_bytes)
 # [i] Versions
 #------------------------------------------------------------------------------
 
-KINDCCM_VERSION='0.10.0'                      # https://github.com/kubernetes-sigs/cloud-provider-kind/releases
-CILIUM_CHART_VERSION='1.19.2'                 # https://artifacthub.io/packages/helm/cilium/cilium
-K8S_GATEWAY_CHART_VERSION='3.6.1'             # https://github.com/k8s-gateway/k8s_gateway/blob/master/charts/k8s-gateway/Chart.yaml
-ARGOCD_CHART_VERSION='9.5.0'                  # https://artifacthub.io/packages/helm/argo-cd-oci/argo-cd
-ARGOWF_CHART_VERSION='1.0.8'                  # https://artifacthub.io/packages/helm/argo/argo-workflows
-PROMETHEUS_CHART_VERSION='29.2.1'             # https://artifacthub.io/packages/helm/prometheus-community/prometheus
-GRAFANA_CHART_VERSION='10.5.15'               # https://artifacthub.io/packages/helm/grafana/grafana
-OTEL_COLLECTOR_CHART_VERSION='0.150.0'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
-VAULT_CHART_VERSION='0.32.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
-CERT_MANAGER_CHART_VERSION='v1.20.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
-KUBERNETES_REPLICATOR_CHART_VERSION='2.12.3'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
-ISTIO_CHART_VERSION='1.29.2'                  # https://artifacthub.io/packages/helm/istio-official/base
-KIALI_CHART_VERSION='2.24.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
+readonly KINDCCM_VERSION='0.10.0'                      # https://github.com/kubernetes-sigs/cloud-provider-kind/releases
+readonly CILIUM_CHART_VERSION='1.19.2'                 # https://artifacthub.io/packages/helm/cilium/cilium
+readonly K8S_GATEWAY_CHART_VERSION='3.6.1'             # https://github.com/k8s-gateway/k8s_gateway/blob/master/charts/k8s-gateway/Chart.yaml
+readonly ARGOCD_CHART_VERSION='9.5.0'                  # https://artifacthub.io/packages/helm/argo-cd-oci/argo-cd
+readonly ARGOWF_CHART_VERSION='1.0.8'                  # https://artifacthub.io/packages/helm/argo/argo-workflows
+readonly PROMETHEUS_CHART_VERSION='29.2.1'             # https://artifacthub.io/packages/helm/prometheus-community/prometheus
+readonly GRAFANA_CHART_VERSION='10.5.15'               # https://artifacthub.io/packages/helm/grafana/grafana
+readonly OTEL_COLLECTOR_CHART_VERSION='0.150.0'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
+readonly VAULT_CHART_VERSION='0.32.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
+readonly CERT_MANAGER_CHART_VERSION='v1.20.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
+readonly KUBERNETES_REPLICATOR_CHART_VERSION='2.12.3'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
+readonly ISTIO_CHART_VERSION='1.29.2'                  # https://artifacthub.io/packages/helm/istio-official/base
+readonly KIALI_CHART_VERSION='2.24.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
 
 #------------------------------------------------------------------------------
 # [i] Cleanup
@@ -117,7 +117,7 @@ create-clusters() {
   blue "───[ KinD clusters ]────────────────────────────────────────────────────"
 
   # Create the temporary directory
-  [ -d ./tmp ] || mkdir -p ./tmp
+  [[ -d ./tmp ]] || mkdir -p ./tmp
 
   # Configure kind
   for cell in $(all_cells); do
@@ -304,7 +304,7 @@ setup-coredns() {
 
   # Get the external LoadBalancer IP (blocks until ready)
   local mngr_exdns_ip
-  mngr_exdns_ip=$(getExtIP "${MNGR}" kube-system exdns-k8s-gateway)
+  mngr_exdns_ip=$(get_ext_ip "${MNGR}" kube-system exdns-k8s-gateway)
 
   # Configure CoreDNS
   for cluster in $(all_clusters); do (
@@ -386,7 +386,7 @@ register-argocd-clusters() {
 
     # Get the external LoadBalancer IP
     local argocd_ip
-    argocd_ip=$(getExtIP "${MNGR}" argocd argocd-server)
+    argocd_ip=$(get_ext_ip "${MNGR}" argocd argocd-server)
 
     # Login to ArgoCD
     argocd login "${argocd_ip}" \
@@ -718,7 +718,7 @@ grafana-git-sync() {
 	contexts:
 	  default:
 	    grafana:
-	      server: http://$(getExtIP "${MNGR}" monitoring grafana)
+	      server: http://$(get_ext_ip "${MNGR}" monitoring grafana)
 	      org-id: 1
 	      user: admin
 	      password: ${PASS}
@@ -763,14 +763,18 @@ tilt-up() {
   # Git clone tilt extensions if not already done, otherwise update.
   # This prevents parallel tilt instances from cloning simultaneously.
   local tilt_ext_dir="/root/.local/share/tilt-dev/tilt_modules/github.com/tilt-dev/tilt-extensions"
-  if [ -d "${tilt_ext_dir}" ]; then git -C "${tilt_ext_dir}" pull --ff-only
-  else git clone https://github.com/tilt-dev/tilt-extensions "${tilt_ext_dir}"; fi
+  if [[ -d "${tilt_ext_dir}" ]]; then
+    git -C "${tilt_ext_dir}" pull --ff-only
+  else
+    git clone https://github.com/tilt-dev/tilt-extensions "${tilt_ext_dir}"
+  fi
 
   # Opt out of analytics
   export TILT_DISABLE_ANALYTICS=1
 
   # Start tilt for each workload cluster
-  local port=9091; for cluster in $(clusters); do
+  local port=9091
+  for cluster in $(clusters); do
     if pgrep -f "tilt up --context kind-${cluster}" &>/dev/null; then
       echo "tilt ${cluster} on port ${port} (running)"
     else

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -143,7 +143,7 @@ create-clusters() {
   ) & done; join
 
   # Get and display all the IPs
-  ensure-ips
+  ensure_ips
   for cluster in $(all_clusters); do
     echo "${cluster} = ${IP[${cluster}]}"
   done
@@ -192,7 +192,7 @@ add-registries-to-containerd() {
 
 setup-kubeconfig() {
   blue "───[ KUBECONFIG ]───────────────────────────────────────────────────────"
-  ensure-ips # Ensure cluster IPs are initialized
+  ensure_ips # Ensure cluster IPs are initialized
 
   # Setup an in-cluster reachable API server config
   cp -f ~/.kube/config ~/.kube/config.in-cluster
@@ -223,7 +223,7 @@ helm-repositories() {
 
 install-cilium() {
   blue "───[ Cilium CNI ]───────────────────────────────────────────────────────"
-  ensure-ips # Ensure cluster IPs are initialized
+  ensure_ips # Ensure cluster IPs are initialized
 
   # Install the Cilium CNI
   for cluster in $(all_clusters); do (
@@ -735,7 +735,7 @@ grafana-git-sync() {
 
 kiali-multicluster() {
   blue "───[ External kiali multi-cluster setup ]───────────────────────────────"
-  ensure-ips # Ensure cluster IPs are initialized
+  ensure_ips # Ensure cluster IPs are initialized
 
   for cluster in $(clusters); do
     retry kiali-prepare-remote-cluster.sh \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -7,6 +7,7 @@
 export MNGR="mnger-1"
 export DOMAIN="demo.lab"
 export PASS='meshlab123'
+readonly MNGR DOMAIN PASS
 export SECTIONS=()
 
 # Define workload cells and their clusters
@@ -24,16 +25,16 @@ declare -A CELL_OF=(
 )
 
 # Colors
-CYAN='\e[1;36m'
-DIM='\e[2m'
-RST='\e[0m'
+readonly CYAN='\e[1;36m'
+readonly DIM='\e[2m'
+readonly RST='\e[0m'
 
 #------------------------------------------------------------------------------
 # List the first ${WLCNT} workload cells (or their clusters)
 #------------------------------------------------------------------------------
 
 # List the first ${WLCNT} workload cells
-function cells {
+cells() {
   local count=0
   for cell in "${!CELLS[@]}"; do
     ((++count > ${WLCNT:-1})) && break
@@ -42,12 +43,12 @@ function cells {
 }
 
 # Manager cell + workload cells above
-function all_cells {
+all_cells() {
   echo "mngr $(cells)"
 }
 
 # List the first ${WLCNT} workload clusters
-function clusters {
+clusters() {
   local count=0
   for cell in "${!CELLS[@]}"; do
     ((++count > ${WLCNT:-1})) && break
@@ -56,7 +57,7 @@ function clusters {
 }
 
 # Manager cluster + workload clusters above
-function all_clusters {
+all_clusters() {
   echo "${MNGR} $(clusters)"
 }
 
@@ -64,7 +65,7 @@ function all_clusters {
 # Returns the CIDR for the given cluster
 #------------------------------------------------------------------------------
 
-function clusterCIDR {
+cluster_cidr() {
   yq '.ipam.operator.clusterPoolIPv4PodCIDRList' < ./charts/cilium/values/"${1}".yaml
 }
 
@@ -72,7 +73,7 @@ function clusterCIDR {
 # Prints the given string in turquoise
 #------------------------------------------------------------------------------
 
-function blue {
+blue() {
   echo -e "\n${CYAN}$1${RST}\n"
 }
 
@@ -80,7 +81,7 @@ function blue {
 # Prints the given string in grey (dim)
 #------------------------------------------------------------------------------
 
-function grey {
+grey() {
   echo -e "${DIM}$1${RST}"
 }
 
@@ -88,7 +89,7 @@ function grey {
 # Retrieves the external IP of the given service
 #------------------------------------------------------------------------------
 
-function getExtIP {
+get_ext_ip() {
   local ip='null'
   until [[ -n "${ip}" && "${ip}" != 'null' ]]; do
     ip=$(kubectl --context="kind-${1}" -n "${2}" get svc "${3}" -o yaml 2>/dev/null | \
@@ -102,11 +103,11 @@ function getExtIP {
 # Publishes the given service in the given VM port
 #------------------------------------------------------------------------------
 
-function publish {
+publish() {
 
   # Get the external IP of the service
   local ip
-  ip=$(getExtIP "${1}" "${2}" "${3}")
+  ip=$(get_ext_ip "${1}" "${2}" "${3}")
 
   # Setup socat for additional edge cases
   nohup socat TCP-LISTEN:"${4}",fork TCP:"${ip}":80 &> /dev/null & disown
@@ -116,7 +117,7 @@ function publish {
 # Wait for all background jobs, fail if any failed
 #------------------------------------------------------------------------------
 
-function join {
+join() {
   local pid status=0
   for pid in $(jobs -p); do wait "${pid}" || status=$?; done
   return "${status}"
@@ -126,7 +127,7 @@ function join {
 # Sum of RX+TX bytes across all non-loopback interfaces in this devcontainer
 #------------------------------------------------------------------------------
 
-function net_bytes {
+net_bytes() {
   awk '/:/ && $1 !~ /^lo:/ { gsub(":", "", $1); rx += $2; tx += $10 }
        END { printf "%.0f", rx + tx }' /proc/net/dev
 }
@@ -135,7 +136,7 @@ function net_bytes {
 # Format a byte count in human-readable IEC units (e.g. 1.2MiB)
 #------------------------------------------------------------------------------
 
-function human_bytes {
+human_bytes() {
   numfmt --to=iec-i --suffix=B --format='%.1f' "${1:-0}"
 }
 
@@ -143,7 +144,7 @@ function human_bytes {
 # Format a duration in seconds as "<m>m <s>s" (e.g. 5m 12s)
 #------------------------------------------------------------------------------
 
-function human_time {
+human_time() {
   printf '%dm %ds' $(( ${1:-0} / 60 )) $(( ${1:-0} % 60 ))
 }
 
@@ -151,7 +152,7 @@ function human_time {
 # Run a command and print its elapsed time and network traffic
 #------------------------------------------------------------------------------
 
-function measure {
+measure() {
   local t=${SECONDS}
   local n; n=$(net_bytes)
   "$@"
@@ -164,7 +165,7 @@ function measure {
 # Retry til success or max attempts reached
 #------------------------------------------------------------------------------
 
-function retry {
+retry() {
   local max=3 attempt=1
   until "$@"; do
     if (( attempt >= max )); then
@@ -182,12 +183,12 @@ function retry {
 #------------------------------------------------------------------------------
 
 # Helper function k0
-function k0 {
+k0() {
   kubectl --context "kind-${MNGR}" "${@}"
 }
 
 # Helper function h0
-function h0 {
+h0() {
   retry helm --kube-context "kind-${MNGR}" "${@}"
 }
 
@@ -197,7 +198,7 @@ function h0 {
 
 declare -gxA IP; IP_INIT=false
 
-function ensure-ips {
+ensure-ips() {
   [[ "${IP_INIT}" == true ]] && return 0
   for cluster in $(all_clusters); do
     IP[${cluster}]=$(docker inspect "${cluster}-control-plane" |

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -198,7 +198,7 @@ h0() {
 
 declare -gxA IP; IP_INIT=false
 
-ensure-ips() {
+ensure_ips() {
   [[ "${IP_INIT}" == true ]] && return 0
   for cluster in $(all_clusters); do
     IP[${cluster}]=$(docker inspect "${cluster}-control-plane" |


### PR DESCRIPTION
Style-only cleanup applying a small set of [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html) rules. No behavior change.

## `bin/meshlab`
- Replace `[ … ]` with `[[ … ]]` (the `tmp` directory check in `create-clusters` and the `tilt_ext_dir` check in `tilt-up`).
- Expand the one-liner `if … then … else … fi` clone-or-pull in `tilt-up` to multi-line form.
- Split `local port=9091; for cluster in $(clusters); do` in `tilt-up` into two statements (one statement per line).
- Mark all version-pin constants (`KINDCCM_VERSION`, every `*_CHART_VERSION`) as `readonly`; inline form keeps the URL comment alignment.
- Update `getExtIP` call sites to `get_ext_ip` (matches the rename in `lib/common.sh`).

## `lib/common.sh`
- Replace `function NAME {` with `NAME() {` for every function (guide forbids the `function` keyword).
- Rename camelCase functions to snake_case: `getExtIP` → `get_ext_ip`, `clusterCIDR` → `cluster_cidr`.
- Mark true constants `readonly`: `MNGR`, `DOMAIN`, `PASS` (after `export`), and the color vars `CYAN`, `DIM`, `RST`.

## Verification
- `shellcheck bin/meshlab lib/common.sh` — no new warnings (only the pre-existing `SC1091` info about following the sourced file from CWD).
- `bash -n bin/meshlab && bash -n lib/common.sh` — both parse cleanly.
- `bin/meshlab list` — still prints all 21 sections (validates sourcing + `readonly` + the `SECTIONS+=( … )` registration pattern).
- `grep -rn 'getExtIP\|clusterCIDR' .` — zero matches in the workspace after the rename.

## Out of scope
Other scripts in `bin/` (`ml`, `devcontainer`, `retoken`, `generate`), strict-mode flags, the `SECTIONS+=( … )` pattern, and a broader `echo -e` → `printf` migration.