### PR TITLE
devcontainer: restrict kube contexts to kind-*

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	},
 	"mounts": [
 		"type=bind,source=/run/host-services/ssh-auth.sock,target=/ssh-agent",
-		"type=bind,source=${localEnv:HOME}/.kube/config,target=/root/.kube/config",
+		"type=bind,source=${localEnv:HOME}/.kube/config,target=/root/.kube/config.host",
 		"type=bind,source=${localWorkspaceFolder}/../istio,target=/workspaces/istio",
 		"type=bind,source=${localWorkspaceFolder}/../k-swarm,target=/workspaces/k-swarm",
 		"type=bind,source=/var/run/docker.sock,target=/var/run/docker-host.sock"

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -55,7 +55,7 @@ cleanup() {
 
   # Only delete clusters we created
   for cluster in $(all_clusters); do
-    kind delete cluster --name "${cluster}" 2>/dev/null || true
+    kind --kubeconfig ~/.kube/config.host delete cluster --name "${cluster}" 2>/dev/null || true
   done
 
   rm -rf ./tmp/*
@@ -137,8 +137,8 @@ create-clusters() {
 
   # Create the clusters
   for cluster in $(all_clusters); do (
-    kind get clusters 2>/dev/null | grep -q "${cluster}" || {
-      kind create cluster --name "${cluster}" --config "./tmp/kind-${CELL_OF[${cluster}]}.yaml" -q
+    kind --kubeconfig ~/.kube/config.host get clusters 2>/dev/null | grep -q "${cluster}" || {
+      kind --kubeconfig ~/.kube/config.host create cluster --name "${cluster}" --config "./tmp/kind-${CELL_OF[${cluster}]}.yaml" -q
     }
   ) & done; join
 
@@ -192,6 +192,21 @@ add-registries-to-containerd() {
 
 setup-kubeconfig() {
   blue "───[ KUBECONFIG ]───────────────────────────────────────────────────────"
+
+  # Regenerate the in-container kubeconfig as a kind-* only snapshot of the
+  # host kubeconfig (bind-mounted RW at ~/.kube/config.host). All kind
+  # invocations in this script use --kubeconfig=~/.kube/config.host, so
+  # clusters created/deleted here remain visible on the host. Inside the
+  # devcontainer, kubectl/helm/istioctl/etc. only ever see kind-* contexts.
+  yq '
+    del(.contexts[] | select(.name | test("^kind-") | not)) |
+    del(.clusters[] | select(.name | test("^kind-") | not)) |
+    del(.users[]    | select(.name | test("^kind-") | not)) |
+    .current-context = (.contexts[0].name // "")
+  ' ~/.kube/config.host > ~/.kube/config.tmp
+  mv ~/.kube/config.tmp ~/.kube/config
+  chmod 600 ~/.kube/config
+
   ensure_ips # Ensure cluster IPs are initialized
 
   # Setup an in-cluster reachable API server config


### PR DESCRIPTION
Working inside the devcontainer with the full host `~/.kube/config` exposed is a foot-gun: a stray `kubectl` invocation could target a production cluster. Outside the devcontainer the user still wants access to all contexts, so we cannot just shrink the host file.

## What

- Host kubeconfig is bind-mounted **read-write** at `/root/.kube/config.host` (was `/root/.kube/config`).
- All `kind` invocations in `bin/meshlab` (`cleanup`, `create-clusters`) now pass `--kubeconfig ~/.kube/config.host`, so clusters created or deleted from the devcontainer are reflected on the host.
- `setup-kubeconfig()` regenerates `~/.kube/config` as a `kind-*` only snapshot of `~/.kube/config.host` via an inline `yq` filter (deletes non-`kind-*` clusters/contexts/users, pins `current-context` to the first remaining `kind-*` or empty, mode 600). The existing `config.in-cluster` derivation is unchanged and now operates on the filtered file.

No new files, no `postStartCommand` hook, no `kind` wrapper.

## Verification

- yq filter run against a synthetic mixed `kind-*` + `gke_*` kubeconfig: only `kind-*` entries remain; `current-context` is rewritten.
- shellcheck clean on the modified `bin/meshlab`.
- Outside the devcontainer the host file is untouched apart from kind-driven add/remove from inside the container.

## Notes

- Ad-hoc `kind create cluster` typed by the user inside the container (i.e. not via `meshlab`) would write to `~/.kube/config` (the filtered snapshot), not the host file. Pass `--kubeconfig ~/.kube/config.host` explicitly to surface it on the host.
- The host`s `current-context` is intentionally discarded inside the container; the in-container default always points to a `kind-*` cluster.