### PR TITLE
feat: add zsh completion for meshlab

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,6 +38,9 @@ RUN echo 'dind() { docker -H unix:///var/run/docker.sock "$@" }' >> /etc/zsh/zsh
     echo "source <(docker completion zsh)" >> /etc/zsh/zshrc && \
     echo "compdef _docker dind dood" >> /etc/zsh/zshrc
 
+# Enable zsh completion for the meshlab CLI (bin/meshlab)
+RUN echo "source /workspaces/meshlab/bin/completions/_meshlab.zsh" >> /etc/zsh/zshrc
+
 # Install Go (https://go.dev/dl/)
 RUN VERSION="1.26.2" && ARCH=$(archmap 'arm64' 'amd64') && \
     curl -fsSL https://go.dev/dl/go${VERSION}.linux-${ARCH}.tar.gz | tar -xzC /usr/local && \

--- a/bin/completions/_meshlab.zsh
+++ b/bin/completions/_meshlab.zsh
@@ -1,0 +1,52 @@
+#compdef meshlab
+#
+# Zsh completion for the `meshlab` CLI (bin/meshlab).
+#
+# Completes top-level subcommands and, for `meshlab run`, the list of
+# sections returned by `meshlab list` so completion never drifts from
+# the SECTIONS array defined in the script itself.
+
+_meshlab() {
+  local -a subcommands sections counts
+  local state
+
+  subcommands=(
+    'create:Create clusters and run all sections (optional WLCNT)'
+    'delete:Tear down clusters and clean up'
+    'watch:Watch cluster state via `ml short`'
+    'list:List all available sections'
+    'run:Run a single section (run <section> [count])'
+  )
+
+  _arguments -C \
+    '1: :->cmd' \
+    '2: :->arg2' \
+    '3: :->arg3' \
+    && return
+
+  case $state in
+    cmd)
+      _describe -t commands 'meshlab subcommand' subcommands
+      ;;
+    arg2)
+      case ${words[2]} in
+        run)
+          sections=(${(f)"$(command meshlab list 2>/dev/null)"})
+          _describe -t sections 'section' sections
+          ;;
+        create)
+          counts=(1 2)
+          _describe -t counts 'workload count' counts
+          ;;
+      esac
+      ;;
+    arg3)
+      if [[ ${words[2]} == run ]]; then
+        counts=(1 2)
+        _describe -t counts 'workload count' counts
+      fi
+      ;;
+  esac
+}
+
+compdef _meshlab meshlab


### PR DESCRIPTION
Adds zsh tab completion for the `meshlab` CLI.

## Changes
- New `bin/completions/_meshlab.zsh` defining `_meshlab` and `compdef _meshlab meshlab`.
  - `meshlab <tab>` → `create | delete | watch | list | run`
  - `meshlab run <tab>` → dynamic section list from `meshlab list` (always in sync with the `SECTIONS` array in `bin/meshlab`)
  - `meshlab run <section> <tab>` → suggested workload counts (`1 2`)
  - `meshlab create <tab>` → suggested workload counts (`1 2`)
- `.devcontainer/Dockerfile`: source the completion file from `/etc/zsh/zshrc` so it loads automatically in the devcontainer.

## Verification
- `zsh -n bin/completions/_meshlab.zsh` passes.
- In an interactive zsh, `_comps[meshlab]` is registered after sourcing and `meshlab list` returns all 21 sections.