### PR TITLE
chore: unify downloads to curl with retry

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,10 @@ LABEL "org.opencontainers.image.source"="https://github.com/h0tbird/meshlab/tree
 ENV LOCALE=en_US.UTF-8 LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 ENV PATH=/workspaces/meshlab/bin:${PATH}
 
+# Shared curl flags for all downloads: fail loud on HTTP errors,
+# follow redirects, and retry on transient/HTTP failures.
+ENV CURL="curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10"
+
 # Architecture helper: archmap <arm64_value> <amd64_value>
 RUN printf '#!/bin/sh\ncase "$(arch)" in aarch64) echo "$1";; x86_64) echo "$2";; esac\n' > /usr/local/bin/archmap && \
     chmod +x /usr/local/bin/archmap
@@ -43,101 +47,101 @@ RUN echo "source <(meshlab completion zsh)" >> /etc/zsh/zshrc
 
 # Install Go (https://go.dev/dl/)
 RUN VERSION="1.26.2" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://go.dev/dl/go${VERSION}.linux-${ARCH}.tar.gz | tar -xzC /usr/local && \
+    $CURL https://go.dev/dl/go${VERSION}.linux-${ARCH}.tar.gz | tar -xzC /usr/local && \
     echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/zsh/zshenv && \
     echo 'export PATH=$PATH:$HOME/go/bin' >> /etc/zsh/zshenv
 
 # Install kind (https://github.com/kubernetes-sigs/kind/releases)
 RUN VERSION="v0.31.0" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/${VERSION}/kind-linux-${ARCH} && \
+    $CURL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/${VERSION}/kind-linux-${ARCH} && \
     chmod +x /usr/local/bin/kind && echo "source <(kind completion zsh)" >> /etc/zsh/zshrc
 
 # Install kubectl (https://cdn.dl.k8s.io/release/stable.txt)
 RUN VERSION="v1.35.3" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /usr/local/bin/kubectl https://dl.k8s.io/release/${VERSION}/bin/linux/${ARCH}/kubectl && \
+    $CURL -o /usr/local/bin/kubectl https://dl.k8s.io/release/${VERSION}/bin/linux/${ARCH}/kubectl && \
     chmod +x /usr/local/bin/kubectl && ln -s /usr/local/bin/kubectl /usr/local/bin/k && \
     echo "source <(kubectl completion zsh)" >> /etc/zsh/zshrc
 
 # Install helm (https://github.com/helm/helm/releases)
 RUN VERSION="v4.1.4" && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
+    $CURL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
     chmod 700 /tmp/get_helm.sh && /tmp/get_helm.sh --version ${VERSION} && rm -f /tmp/get_helm.sh && \
     echo "source <(helm completion zsh)" >> /etc/zsh/zshrc
 
 # Install yq (https://github.com/mikefarah/yq/releases)
 RUN VERSION="v4.52.5" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${VERSION}/yq_linux_${ARCH} && \
+    $CURL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${VERSION}/yq_linux_${ARCH} && \
     chmod +x /usr/local/bin/yq && echo "source <(yq completion zsh)" >> /etc/zsh/zshrc
 
 # Install argocd (https://github.com/argoproj/argo-cd/releases)
 RUN VERSION="v3.3.6" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/${VERSION}/argocd-linux-${ARCH} && \
+    $CURL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/${VERSION}/argocd-linux-${ARCH} && \
     chmod +x /usr/local/bin/argocd && echo "source <(argocd completion zsh)" >> /etc/zsh/zshrc
 
 # Install argo (https://github.com/argoproj/argo-workflows/releases)
 RUN VERSION="v4.0.4" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/argoproj/argo-workflows/releases/download/${VERSION}/argo-linux-${ARCH}.gz | gunzip -c > /usr/local/bin/argo && \
+    $CURL https://github.com/argoproj/argo-workflows/releases/download/${VERSION}/argo-linux-${ARCH}.gz | gunzip -c > /usr/local/bin/argo && \
     chmod +x /usr/local/bin/argo && echo "source <(argo completion zsh)" >> /etc/zsh/zshrc
 
 # Install cilium-cli (https://github.com/cilium/cilium-cli/releases)
 RUN VERSION="v0.19.2" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/cilium/cilium-cli/releases/download/${VERSION}/cilium-linux-${ARCH}.tar.gz | tar -xz -C /usr/local/bin/ && \
+    $CURL https://github.com/cilium/cilium-cli/releases/download/${VERSION}/cilium-linux-${ARCH}.tar.gz | tar -xz -C /usr/local/bin/ && \
     chmod +x /usr/local/bin/cilium && echo "source <(cilium completion zsh)" >> /etc/zsh/zshrc
 
 # Install istioctl (https://github.com/istio/istio/releases)
 RUN VERSION="1.29.2" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /tmp/istio.tar.gz https://github.com/istio/istio/releases/download/${VERSION}/istio-${VERSION}-linux-${ARCH}.tar.gz && \
+    $CURL -o /tmp/istio.tar.gz https://github.com/istio/istio/releases/download/${VERSION}/istio-${VERSION}-linux-${ARCH}.tar.gz && \
     tar -xC /usr/local/bin --strip-components 2 -f /tmp/istio.tar.gz istio-${VERSION}/bin/istioctl && rm -f /tmp/istio.tar.gz && \
     echo "source <(istioctl completion zsh)" >> /etc/zsh/zshrc
 
 # Install step (https://github.com/smallstep/cli/releases)
 RUN VERSION="0.30.2" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -O https://dl.smallstep.com/gh-release/cli/gh-release-header/v${VERSION}/step-cli_${VERSION}-1_${ARCH}.deb && \
+    $CURL -O https://dl.smallstep.com/gh-release/cli/gh-release-header/v${VERSION}/step-cli_${VERSION}-1_${ARCH}.deb && \
     dpkg -i step-cli_${VERSION}-1_${ARCH}.deb && rm -f step-cli_${VERSION}-1_${ARCH}.deb && \
     echo "source <(step completion zsh)" >> /etc/zsh/zshrc
 
 # Install gh (https://github.com/cli/cli/releases)
 RUN VERSION="2.89.0" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -O https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_${ARCH}.deb && \
+    $CURL -O https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_${ARCH}.deb && \
     dpkg -i gh_${VERSION}_linux_${ARCH}.deb && rm -f gh_${VERSION}_linux_${ARCH}.deb && \
     echo "source <(gh completion -s zsh)" >> /etc/zsh/zshrc
 
 # Install mdbook (https://github.com/rust-lang/mdBook/releases)
 RUN VERSION="v0.5.2" && ARCH=$(archmap 'aarch64' 'x86_64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/rust-lang/mdbook/releases/download/${VERSION}/mdbook-${VERSION}-${ARCH}-unknown-linux-musl.tar.gz | \
+    $CURL https://github.com/rust-lang/mdbook/releases/download/${VERSION}/mdbook-${VERSION}-${ARCH}-unknown-linux-musl.tar.gz | \
     tar -xzC /usr/local/bin mdbook && echo "source <(mdbook completions zsh)" >> /etc/zsh/zshrc
 
 # Install swarmctl (https://github.com/h0tbird/k-swarm/releases)
 RUN VERSION="0.3.7" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/h0tbird/k-swarm/releases/download/v${VERSION}/swarmctl_${VERSION}_linux_${ARCH}.tar.gz | \
+    $CURL https://github.com/h0tbird/k-swarm/releases/download/v${VERSION}/swarmctl_${VERSION}_linux_${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin swarmctl && echo "source <(swarmctl completion zsh)" >> /etc/zsh/zshrc
 
 # Install btop (https://github.com/aristocratos/btop/releases)
 RUN VERSION="1.4.6" && ARCH=$(archmap 'aarch64' 'x86_64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/aristocratos/btop/releases/download/v${VERSION}/btop-${ARCH}-unknown-linux-musl.tbz | \
+    $CURL https://github.com/aristocratos/btop/releases/download/v${VERSION}/btop-${ARCH}-unknown-linux-musl.tbz | \
     tar -xjC /usr/local/bin --strip-components 3 -f - ./btop/bin/btop
 
 # Install tilt (https://github.com/tilt-dev/tilt/releases)
 RUN VERSION="0.37.1" && ARCH=$(archmap 'arm64' 'x86_64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/tilt-dev/tilt/releases/download/v${VERSION}/tilt.${VERSION}.linux.${ARCH}.tar.gz | \
+    $CURL https://github.com/tilt-dev/tilt/releases/download/v${VERSION}/tilt.${VERSION}.linux.${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin tilt && echo "source <(tilt completion zsh)" >> /etc/zsh/zshrc
 
 # Install crane (https://github.com/google/go-containerregistry/releases)
 RUN VERSION="v0.21.5" && ARCH=$(archmap 'arm64' 'i386') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_${ARCH}.tar.gz | \
+    $CURL https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin crane && echo "source <(crane completion zsh)" >> /etc/zsh/zshrc
 
 # Install grafanactl (https://github.com/grafana/grafanactl/releases)
 RUN VERSION="v0.1.9" && ARCH=$(archmap 'arm64' 'x86_64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/grafana/grafanactl/releases/download/${VERSION}/grafanactl_Linux_${ARCH}.tar.gz | \
+    $CURL https://github.com/grafana/grafanactl/releases/download/${VERSION}/grafanactl_Linux_${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin grafanactl && echo "source <(grafanactl completion zsh)" >> /etc/zsh/zshrc
 
 # Install bat (https://github.com/sharkdp/bat/releases)
 RUN VERSION="0.26.1" && ARCH=$(archmap 'aarch64' 'x86_64') && \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/sharkdp/bat/releases/download/v${VERSION}/bat-v${VERSION}-${ARCH}-unknown-linux-musl.tar.gz | \
+    $CURL https://github.com/sharkdp/bat/releases/download/v${VERSION}/bat-v${VERSION}-${ARCH}-unknown-linux-musl.tar.gz | \
     tar -xzC /usr/local/bin --strip-components 1 -f - bat-v${VERSION}-${ARCH}-unknown-linux-musl/bat
 
 # Install kiali-prepare-remote-cluster.sh (https://github.com/kiali/kiali)
-RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /usr/local/bin/kiali-prepare-remote-cluster.sh \
+RUN $CURL -o /usr/local/bin/kiali-prepare-remote-cluster.sh \
     https://raw.githubusercontent.com/kiali/kiali/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh && \
     chmod +x /usr/local/bin/kiali-prepare-remote-cluster.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,101 +43,101 @@ RUN echo "source <(meshlab completion zsh)" >> /etc/zsh/zshrc
 
 # Install Go (https://go.dev/dl/)
 RUN VERSION="1.26.2" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL https://go.dev/dl/go${VERSION}.linux-${ARCH}.tar.gz | tar -xzC /usr/local && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://go.dev/dl/go${VERSION}.linux-${ARCH}.tar.gz | tar -xzC /usr/local && \
     echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/zsh/zshenv && \
     echo 'export PATH=$PATH:$HOME/go/bin' >> /etc/zsh/zshenv
 
 # Install kind (https://github.com/kubernetes-sigs/kind/releases)
 RUN VERSION="v0.31.0" && ARCH=$(archmap 'arm64' 'amd64') && \
-    wget https://github.com/kubernetes-sigs/kind/releases/download/${VERSION}/kind-linux-${ARCH} -O /usr/local/bin/kind && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/${VERSION}/kind-linux-${ARCH} && \
     chmod +x /usr/local/bin/kind && echo "source <(kind completion zsh)" >> /etc/zsh/zshrc
 
 # Install kubectl (https://cdn.dl.k8s.io/release/stable.txt)
 RUN VERSION="v1.35.3" && ARCH=$(archmap 'arm64' 'amd64') && \
-    wget https://dl.k8s.io/release/${VERSION}/bin/linux/${ARCH}/kubectl -O /usr/local/bin/kubectl && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /usr/local/bin/kubectl https://dl.k8s.io/release/${VERSION}/bin/linux/${ARCH}/kubectl && \
     chmod +x /usr/local/bin/kubectl && ln -s /usr/local/bin/kubectl /usr/local/bin/k && \
     echo "source <(kubectl completion zsh)" >> /etc/zsh/zshrc
 
 # Install helm (https://github.com/helm/helm/releases)
 RUN VERSION="v4.1.4" && \
-    curl -fsSLo /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
     chmod 700 /tmp/get_helm.sh && /tmp/get_helm.sh --version ${VERSION} && rm -f /tmp/get_helm.sh && \
     echo "source <(helm completion zsh)" >> /etc/zsh/zshrc
 
 # Install yq (https://github.com/mikefarah/yq/releases)
 RUN VERSION="v4.52.5" && ARCH=$(archmap 'arm64' 'amd64') && \
-    wget https://github.com/mikefarah/yq/releases/download/${VERSION}/yq_linux_${ARCH} -O /usr/local/bin/yq && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${VERSION}/yq_linux_${ARCH} && \
     chmod +x /usr/local/bin/yq && echo "source <(yq completion zsh)" >> /etc/zsh/zshrc
 
 # Install argocd (https://github.com/argoproj/argo-cd/releases)
 RUN VERSION="v3.3.6" && ARCH=$(archmap 'arm64' 'amd64') && \
-    wget https://github.com/argoproj/argo-cd/releases/download/${VERSION}/argocd-linux-${ARCH} -qO /usr/local/bin/argocd && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/${VERSION}/argocd-linux-${ARCH} && \
     chmod +x /usr/local/bin/argocd && echo "source <(argocd completion zsh)" >> /etc/zsh/zshrc
 
 # Install argo (https://github.com/argoproj/argo-workflows/releases)
 RUN VERSION="v4.0.4" && ARCH=$(archmap 'arm64' 'amd64') && \
-    wget -qO- https://github.com/argoproj/argo-workflows/releases/download/${VERSION}/argo-linux-${ARCH}.gz | gunzip -c > /usr/local/bin/argo && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/argoproj/argo-workflows/releases/download/${VERSION}/argo-linux-${ARCH}.gz | gunzip -c > /usr/local/bin/argo && \
     chmod +x /usr/local/bin/argo && echo "source <(argo completion zsh)" >> /etc/zsh/zshrc
 
 # Install cilium-cli (https://github.com/cilium/cilium-cli/releases)
 RUN VERSION="v0.19.2" && ARCH=$(archmap 'arm64' 'amd64') && \
-    wget -qO- https://github.com/cilium/cilium-cli/releases/download/${VERSION}/cilium-linux-${ARCH}.tar.gz | tar -xz -C /usr/local/bin/ && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/cilium/cilium-cli/releases/download/${VERSION}/cilium-linux-${ARCH}.tar.gz | tar -xz -C /usr/local/bin/ && \
     chmod +x /usr/local/bin/cilium && echo "source <(cilium completion zsh)" >> /etc/zsh/zshrc
 
 # Install istioctl (https://github.com/istio/istio/releases)
 RUN VERSION="1.29.2" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSLo /tmp/istio.tar.gz https://github.com/istio/istio/releases/download/${VERSION}/istio-${VERSION}-linux-${ARCH}.tar.gz && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /tmp/istio.tar.gz https://github.com/istio/istio/releases/download/${VERSION}/istio-${VERSION}-linux-${ARCH}.tar.gz && \
     tar -xC /usr/local/bin --strip-components 2 -f /tmp/istio.tar.gz istio-${VERSION}/bin/istioctl && rm -f /tmp/istio.tar.gz && \
     echo "source <(istioctl completion zsh)" >> /etc/zsh/zshrc
 
 # Install step (https://github.com/smallstep/cli/releases)
 RUN VERSION="0.30.2" && ARCH=$(archmap 'arm64' 'amd64') && \
-    wget -q https://dl.smallstep.com/gh-release/cli/gh-release-header/v${VERSION}/step-cli_${VERSION}-1_${ARCH}.deb && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -O https://dl.smallstep.com/gh-release/cli/gh-release-header/v${VERSION}/step-cli_${VERSION}-1_${ARCH}.deb && \
     dpkg -i step-cli_${VERSION}-1_${ARCH}.deb && rm -f step-cli_${VERSION}-1_${ARCH}.deb && \
     echo "source <(step completion zsh)" >> /etc/zsh/zshrc
 
 # Install gh (https://github.com/cli/cli/releases)
 RUN VERSION="2.89.0" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSLO https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_${ARCH}.deb && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -O https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_${ARCH}.deb && \
     dpkg -i gh_${VERSION}_linux_${ARCH}.deb && rm -f gh_${VERSION}_linux_${ARCH}.deb && \
     echo "source <(gh completion -s zsh)" >> /etc/zsh/zshrc
 
 # Install mdbook (https://github.com/rust-lang/mdBook/releases)
 RUN VERSION="v0.5.2" && ARCH=$(archmap 'aarch64' 'x86_64') && \
-    curl -fsSL https://github.com/rust-lang/mdbook/releases/download/${VERSION}/mdbook-${VERSION}-${ARCH}-unknown-linux-musl.tar.gz | \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/rust-lang/mdbook/releases/download/${VERSION}/mdbook-${VERSION}-${ARCH}-unknown-linux-musl.tar.gz | \
     tar -xzC /usr/local/bin mdbook && echo "source <(mdbook completions zsh)" >> /etc/zsh/zshrc
 
 # Install swarmctl (https://github.com/h0tbird/k-swarm/releases)
 RUN VERSION="0.3.7" && ARCH=$(archmap 'arm64' 'amd64') && \
-    curl -fsSL --retry 5 --retry-all-errors https://github.com/h0tbird/k-swarm/releases/download/v${VERSION}/swarmctl_${VERSION}_linux_${ARCH}.tar.gz | \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/h0tbird/k-swarm/releases/download/v${VERSION}/swarmctl_${VERSION}_linux_${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin swarmctl && echo "source <(swarmctl completion zsh)" >> /etc/zsh/zshrc
 
 # Install btop (https://github.com/aristocratos/btop/releases)
 RUN VERSION="1.4.6" && ARCH=$(archmap 'aarch64' 'x86_64') && \
-    wget -qO- https://github.com/aristocratos/btop/releases/download/v${VERSION}/btop-${ARCH}-unknown-linux-musl.tbz | \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/aristocratos/btop/releases/download/v${VERSION}/btop-${ARCH}-unknown-linux-musl.tbz | \
     tar -xjC /usr/local/bin --strip-components 3 -f - ./btop/bin/btop
 
 # Install tilt (https://github.com/tilt-dev/tilt/releases)
 RUN VERSION="0.37.1" && ARCH=$(archmap 'arm64' 'x86_64') && \
-    curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v${VERSION}/tilt.${VERSION}.linux.${ARCH}.tar.gz | \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/tilt-dev/tilt/releases/download/v${VERSION}/tilt.${VERSION}.linux.${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin tilt && echo "source <(tilt completion zsh)" >> /etc/zsh/zshrc
 
 # Install crane (https://github.com/google/go-containerregistry/releases)
 RUN VERSION="v0.21.5" && ARCH=$(archmap 'arm64' 'i386') && \
-    curl -fsSL https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_${ARCH}.tar.gz | \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin crane && echo "source <(crane completion zsh)" >> /etc/zsh/zshrc
 
 # Install grafanactl (https://github.com/grafana/grafanactl/releases)
 RUN VERSION="v0.1.9" && ARCH=$(archmap 'arm64' 'x86_64') && \
-    curl -fsSL https://github.com/grafana/grafanactl/releases/download/${VERSION}/grafanactl_Linux_${ARCH}.tar.gz | \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/grafana/grafanactl/releases/download/${VERSION}/grafanactl_Linux_${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin grafanactl && echo "source <(grafanactl completion zsh)" >> /etc/zsh/zshrc
 
 # Install bat (https://github.com/sharkdp/bat/releases)
 RUN VERSION="0.26.1" && ARCH=$(archmap 'aarch64' 'x86_64') && \
-    curl -fsSL https://github.com/sharkdp/bat/releases/download/v${VERSION}/bat-v${VERSION}-${ARCH}-unknown-linux-musl.tar.gz | \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 https://github.com/sharkdp/bat/releases/download/v${VERSION}/bat-v${VERSION}-${ARCH}-unknown-linux-musl.tar.gz | \
     tar -xzC /usr/local/bin --strip-components 1 -f - bat-v${VERSION}-${ARCH}-unknown-linux-musl/bat
 
 # Install kiali-prepare-remote-cluster.sh (https://github.com/kiali/kiali)
-RUN curl -sLo /usr/local/bin/kiali-prepare-remote-cluster.sh \
+RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -o /usr/local/bin/kiali-prepare-remote-cluster.sh \
     https://raw.githubusercontent.com/kiali/kiali/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh && \
     chmod +x /usr/local/bin/kiali-prepare-remote-cluster.sh

--- a/hack/Dockerfile.toolbox
+++ b/hack/Dockerfile.toolbox
@@ -11,11 +11,11 @@ ARG VERSION=1.21.2
 
 WORKDIR /tmp/
 
-RUN apk --update add --virtual verify gpgme unzip \
+RUN apk --update add --virtual verify curl gpgme unzip \
  && PLATFORM=$(echo ${TARGETPLATFORM} | sed -e 's|/|_|g') \
- && wget https://releases.hashicorp.com/vault/${VERSION}/vault_${VERSION}_${PLATFORM}.zip \
- && wget https://releases.hashicorp.com/vault/${VERSION}/vault_${VERSION}_SHA256SUMS \
- && wget https://releases.hashicorp.com/vault/${VERSION}/vault_${VERSION}_SHA256SUMS.sig \
+ && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -O https://releases.hashicorp.com/vault/${VERSION}/vault_${VERSION}_${PLATFORM}.zip \
+ && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -O https://releases.hashicorp.com/vault/${VERSION}/vault_${VERSION}_SHA256SUMS \
+ && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10 -O https://releases.hashicorp.com/vault/${VERSION}/vault_${VERSION}_SHA256SUMS.sig \
  && gpg --keyserver keyserver.ubuntu.com --recv-key 0x72D7468F \
  && gpg --verify /tmp/vault_${VERSION}_SHA256SUMS.sig \
  && cat vault_${VERSION}_SHA256SUMS | grep ${PLATFORM} | sha256sum -c \


### PR DESCRIPTION
## Summary

Replace every `wget` invocation in `.devcontainer/Dockerfile` and `hack/Dockerfile.toolbox` with `curl`, and apply a uniform retry-enabled flag set to **all** download commands (including the ones that were already using `curl` without retry).

Standard flag set:

```
curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10
```

(plus `-o <path>`, `-O`, or a pipe into `tar`/`gunzip` as needed).

## Why curl over wget?

- `curl` is already installed in the devcontainer base image — `wget` is incidental and never explicitly installed.
- `curl` has first-class retry semantics. GNU `wget --tries` does not retry on HTTP errors by default, and the BusyBox `wget` shipped in the alpine toolbox image lacks most retry flags entirely.
- One tool = one consistent flag style across all `RUN` layers, which reduces flaky devcontainer/toolbox builds caused by transient network failures (the original motivation — same pattern already in use for the `swarmctl` line).

## Changes

- `.devcontainer/Dockerfile` — converts 8 `wget` calls (kind, kubectl, yq, argocd, argo, cilium-cli, step, btop) and normalizes the existing `curl` calls (go, helm, istioctl, gh, mdbook, swarmctl, tilt, crane, grafanactl, bat, kiali script) so retry is truly universal.
- `hack/Dockerfile.toolbox` — adds `curl` to the `apk add --virtual verify` list and replaces the three vault `wget` calls with `curl -O`. Remote filenames are preserved, so the subsequent `gpg --verify`, `sha256sum -c`, and `unzip` steps work unchanged.

## Verification

- `grep -rn '\bwget\b' .devcontainer hack` → no matches.
- Version pins, layer ordering, and completion echoes are untouched.
