### PR TITLE
fix(devcontainer): P0 Dockerfile fixes (crane arch, pipefail, archmap)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,12 +11,17 @@ LABEL "org.opencontainers.image.source"="https://github.com/h0tbird/meshlab/tree
 ENV LOCALE=en_US.UTF-8 LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 ENV PATH=/workspaces/meshlab/bin:${PATH}
 
+# Use bash with pipefail so failures in piped commands (curl | tar, etc.) are
+# surfaced instead of silently ignored.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Shared curl flags for all downloads: fail loud on HTTP errors,
 # follow redirects, and retry on transient/HTTP failures.
 ENV CURL="curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10"
 
 # Architecture helper: archmap <arm64_value> <amd64_value>
-RUN printf '#!/bin/sh\ncase "$(arch)" in aarch64) echo "$1";; x86_64) echo "$2";; esac\n' > /usr/local/bin/archmap && \
+# Exits non-zero on unsupported architectures so broken downloads fail loudly.
+RUN printf '#!/bin/sh\ncase "$(arch)" in aarch64) echo "$1";; x86_64) echo "$2";; *) echo "archmap: unsupported arch $(arch)" >&2; exit 1;; esac\n' > /usr/local/bin/archmap && \
     chmod +x /usr/local/bin/archmap
 
 # Install base packages
@@ -127,7 +132,7 @@ RUN VERSION="0.37.1" && ARCH=$(archmap 'arm64' 'x86_64') && \
     tar -xzC /usr/local/bin tilt && echo "source <(tilt completion zsh)" >> /etc/zsh/zshrc
 
 # Install crane (https://github.com/google/go-containerregistry/releases)
-RUN VERSION="v0.21.5" && ARCH=$(archmap 'arm64' 'i386') && \
+RUN VERSION="v0.21.5" && ARCH=$(archmap 'arm64' 'x86_64') && \
     $CURL https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin crane && echo "source <(crane completion zsh)" >> /etc/zsh/zshrc
 


### PR DESCRIPTION
## Summary

Three P0 fixes to `.devcontainer/Dockerfile` surfaced during a review.

### Changes

1. **Fix `crane` architecture mapping** — `archmap 'arm64' 'i386'` was downloading the 32-bit x86 build on amd64 hosts. `go-containerregistry` releases use `x86_64` for amd64. Changed to `archmap 'arm64' 'x86_64'`.
2. **Add `SHELL ["/bin/bash", "-o", "pipefail", "-c"]`** — without `pipefail`, failures in piped commands like `curl … | tar …` are silently ignored. `curl -f` only covers the curl side; tar/gunzip failures now fail the build.
3. **Make `archmap` fail loudly on unsupported architectures** — previously it silently produced an empty string on anything other than `aarch64`/`x86_64`, leading to mysterious broken download URLs. Now exits non-zero with a clear message.

### Why

Correctness bug (#1) and defense-in-depth against silent build failures (#2, #3). All three are minimal, low-risk changes contained to the devcontainer image build.

### Notes

Follow-ups (P1/P2 — checksums, pinning the base image and `master`-sourced scripts, locale generation, completion caching, an install helper) can be tracked separately.