### PR TITLE
chore(devcontainer): generate locale, lazy DOCKER_API_VERSION, apt-get cleanups

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,19 +25,26 @@ RUN printf '#!/bin/sh\ncase "$(arch)" in aarch64) echo "$1";; x86_64) echo "$2";
     chmod +x /usr/local/bin/archmap
 
 # Install base packages
-RUN apt update && \
-    apt install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     curl jq iputils-ping dnsutils neovim socat \
     netcat-openbsd apache2-utils shellcheck \
-    python3 ripgrep && \
-    apt autoremove -y && apt clean -y && \
+    python3 ripgrep locales && \
+    locale-gen en_US.UTF-8 && \
+    apt-get clean -y && \
     rm -rf /var/lib/apt/lists/* && \
     chmod -x /etc/update-motd.d/*
 
-# Set zsh as default shell
+# Set zsh as default shell.
+# DOCKER_API_VERSION is exported in /etc/zsh/zprofile (login shells only)
+# rather than zshenv (every shell), and only when the docker socket exists,
+# to avoid a curl on every interactive subshell startup.
 RUN chsh -s /usr/bin/zsh root && \
     chsh -s /usr/bin/zsh vscode && \
-    echo 'export DOCKER_API_VERSION=$(curl -s --unix-socket /var/run/docker.sock http://localhost/version | jq -r .ApiVersion)' >> /etc/zsh/zshenv && \
+    printf '%s\n' \
+      'if [ -S /var/run/docker.sock ]; then' \
+      '  export DOCKER_API_VERSION=$(curl -s --unix-socket /var/run/docker.sock http://localhost/version | jq -r .ApiVersion)' \
+      'fi' >> /etc/zsh/zprofile && \
     sed -i '/^ZSH_THEME/c\ZSH_THEME="robbyrussell"' /root/.zshrc && \
     sed -i '/^ZSH_THEME/c\ZSH_THEME="robbyrussell"' /home/vscode/.zshrc
 
@@ -100,13 +107,13 @@ RUN VERSION="1.29.2" && ARCH=$(archmap 'arm64' 'amd64') && \
     echo "source <(istioctl completion zsh)" >> /etc/zsh/zshrc
 
 # Install step (https://github.com/smallstep/cli/releases)
-RUN VERSION="0.30.2" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="0.30.2" && ARCH=$(archmap 'arm64' 'amd64') && cd /tmp && \
     $CURL -O https://dl.smallstep.com/gh-release/cli/gh-release-header/v${VERSION}/step-cli_${VERSION}-1_${ARCH}.deb && \
     dpkg -i step-cli_${VERSION}-1_${ARCH}.deb && rm -f step-cli_${VERSION}-1_${ARCH}.deb && \
     echo "source <(step completion zsh)" >> /etc/zsh/zshrc
 
 # Install gh (https://github.com/cli/cli/releases)
-RUN VERSION="2.89.0" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="2.89.0" && ARCH=$(archmap 'arm64' 'amd64') && cd /tmp && \
     $CURL -O https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_${ARCH}.deb && \
     dpkg -i gh_${VERSION}_linux_${ARCH}.deb && rm -f gh_${VERSION}_linux_${ARCH}.deb && \
     echo "source <(gh completion -s zsh)" >> /etc/zsh/zshrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,8 +16,10 @@ ENV PATH=/workspaces/meshlab/bin:${PATH}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Shared curl flags for all downloads: fail loud on HTTP errors,
-# follow redirects, and retry on transient/HTTP failures.
-ENV CURL="curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10"
+# follow redirects, and retry on transient/HTTP failures. Uses curl's
+# built-in exponential backoff (no --retry-delay) capped by --retry-max-time
+# so transient CDN incidents (e.g. GitHub 5xx) don't fail the build too fast.
+ENV CURL="curl -fsSL --retry 8 --retry-all-errors --retry-max-time 120 --connect-timeout 10"
 
 # Architecture helper: archmap <arm64_value> <amd64_value>
 # Exits non-zero on unsupported architectures so broken downloads fail loudly.


### PR DESCRIPTION
## Summary

P2 quality cleanups for `.devcontainer/Dockerfile`. Stacked on top of #38.

### Changes

1. **Generate the en_US.UTF-8 locale** — `LANG`/`LC_ALL` were set in `ENV` but the `locales` package was never installed and `locale-gen` was never run, so `LC_ALL` produced warnings on shell startup.
2. **Lazy `DOCKER_API_VERSION` lookup** — moved from `/etc/zsh/zshenv` (sourced for *every* shell, including non-interactive ones) to `/etc/zsh/zprofile` (login shells only) and guarded with a socket-existence check. Removes a per-subshell `curl` to the docker socket.
3. **`apt` → `apt-get`** — `apt` prints "WARNING: apt does not have a stable CLI interface" in scripts; `apt-get` is the script-safe interface.
4. **Drop `apt autoremove`** — no-op after a single explicit install of named packages.
5. **`cd /tmp` for `.deb` downloads** — `step` and `gh` were `curl -O`-ing into `/` (the build cwd). Move them to `/tmp` so the workspace stays clean even if a later `RUN` forgets the `rm`.

### Why

All low-risk hygiene items surfaced during the original review. No functional change to installed tooling.

### Notes

Larger follow-ups left for separate PRs:
- **Completion caching** (review #10): convert `source <(tool completion zsh)` lines to pre-generated files under `/usr/share/zsh/vendor-completions/` at build time. Touches every install layer and has subtle exceptions (`docker`, `meshlab` aren't available at build), so it deserves its own PR.
- **Install helper + sha256 verification** (review #4, #12): pairs naturally — extract a single `install-release` helper and add per-download checksum enforcement together.

Stacked on #38; merge that one first.