### PR TITLE
Merge fix/devcontainer-dockerfile-p1 into master (includes #39)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # See (https://mcr.microsoft.com/en-us/artifact/mar/devcontainers/base/about)
 # See (https://github.com/devcontainers/images/tree/main/src/base-ubuntu)
-FROM mcr.microsoft.com/devcontainers/base:ubuntu
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
 # Labels
 LABEL "org.opencontainers.image.title"="Meshlab's devcontainer"
@@ -68,8 +68,9 @@ RUN VERSION="v1.35.3" && ARCH=$(archmap 'arm64' 'amd64') && \
     echo "source <(kubectl completion zsh)" >> /etc/zsh/zshrc
 
 # Install helm (https://github.com/helm/helm/releases)
+# Pin the installer script to the same tag we install for reproducibility.
 RUN VERSION="v4.1.4" && \
-    $CURL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
+    $CURL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/${VERSION}/scripts/get-helm-3 && \
     chmod 700 /tmp/get_helm.sh && /tmp/get_helm.sh --version ${VERSION} && rm -f /tmp/get_helm.sh && \
     echo "source <(helm completion zsh)" >> /etc/zsh/zshrc
 
@@ -147,6 +148,8 @@ RUN VERSION="0.26.1" && ARCH=$(archmap 'aarch64' 'x86_64') && \
     tar -xzC /usr/local/bin --strip-components 1 -f - bat-v${VERSION}-${ARCH}-unknown-linux-musl/bat
 
 # Install kiali-prepare-remote-cluster.sh (https://github.com/kiali/kiali)
-RUN $CURL -o /usr/local/bin/kiali-prepare-remote-cluster.sh \
-    https://raw.githubusercontent.com/kiali/kiali/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh && \
+# Pin to a specific commit so image builds are reproducible.
+RUN KIALI_SHA="220965a679679a1fef32490899bc27897f8950bd" && \
+    $CURL -o /usr/local/bin/kiali-prepare-remote-cluster.sh \
+    https://raw.githubusercontent.com/kiali/kiali/${KIALI_SHA}/hack/istio/multicluster/kiali-prepare-remote-cluster.sh && \
     chmod +x /usr/local/bin/kiali-prepare-remote-cluster.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,8 +16,10 @@ ENV PATH=/workspaces/meshlab/bin:${PATH}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Shared curl flags for all downloads: fail loud on HTTP errors,
-# follow redirects, and retry on transient/HTTP failures.
-ENV CURL="curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10"
+# follow redirects, and retry on transient/HTTP failures. Uses curl's
+# built-in exponential backoff (no --retry-delay) capped by --retry-max-time
+# so transient CDN incidents (e.g. GitHub 5xx) don't fail the build too fast.
+ENV CURL="curl -fsSL --retry 8 --retry-all-errors --retry-max-time 120 --connect-timeout 10"
 
 # Architecture helper: archmap <arm64_value> <amd64_value>
 # Exits non-zero on unsupported architectures so broken downloads fail loudly.
@@ -25,19 +27,26 @@ RUN printf '#!/bin/sh\ncase "$(arch)" in aarch64) echo "$1";; x86_64) echo "$2";
     chmod +x /usr/local/bin/archmap
 
 # Install base packages
-RUN apt update && \
-    apt install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     curl jq iputils-ping dnsutils neovim socat \
     netcat-openbsd apache2-utils shellcheck \
-    python3 ripgrep && \
-    apt autoremove -y && apt clean -y && \
+    python3 ripgrep locales && \
+    locale-gen en_US.UTF-8 && \
+    apt-get clean -y && \
     rm -rf /var/lib/apt/lists/* && \
     chmod -x /etc/update-motd.d/*
 
-# Set zsh as default shell
+# Set zsh as default shell.
+# DOCKER_API_VERSION is exported in /etc/zsh/zprofile (login shells only)
+# rather than zshenv (every shell), and only when the docker socket exists,
+# to avoid a curl on every interactive subshell startup.
 RUN chsh -s /usr/bin/zsh root && \
     chsh -s /usr/bin/zsh vscode && \
-    echo 'export DOCKER_API_VERSION=$(curl -s --unix-socket /var/run/docker.sock http://localhost/version | jq -r .ApiVersion)' >> /etc/zsh/zshenv && \
+    printf '%s\n' \
+      'if [ -S /var/run/docker.sock ]; then' \
+      '  export DOCKER_API_VERSION=$(curl -s --unix-socket /var/run/docker.sock http://localhost/version | jq -r .ApiVersion)' \
+      'fi' >> /etc/zsh/zprofile && \
     sed -i '/^ZSH_THEME/c\ZSH_THEME="robbyrussell"' /root/.zshrc && \
     sed -i '/^ZSH_THEME/c\ZSH_THEME="robbyrussell"' /home/vscode/.zshrc
 
@@ -100,13 +109,13 @@ RUN VERSION="1.29.2" && ARCH=$(archmap 'arm64' 'amd64') && \
     echo "source <(istioctl completion zsh)" >> /etc/zsh/zshrc
 
 # Install step (https://github.com/smallstep/cli/releases)
-RUN VERSION="0.30.2" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="0.30.2" && ARCH=$(archmap 'arm64' 'amd64') && cd /tmp && \
     $CURL -O https://dl.smallstep.com/gh-release/cli/gh-release-header/v${VERSION}/step-cli_${VERSION}-1_${ARCH}.deb && \
     dpkg -i step-cli_${VERSION}-1_${ARCH}.deb && rm -f step-cli_${VERSION}-1_${ARCH}.deb && \
     echo "source <(step completion zsh)" >> /etc/zsh/zshrc
 
 # Install gh (https://github.com/cli/cli/releases)
-RUN VERSION="2.89.0" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="2.89.0" && ARCH=$(archmap 'arm64' 'amd64') && cd /tmp && \
     $CURL -O https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_${ARCH}.deb && \
     dpkg -i gh_${VERSION}_linux_${ARCH}.deb && rm -f gh_${VERSION}_linux_${ARCH}.deb && \
     echo "source <(gh completion -s zsh)" >> /etc/zsh/zshrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -68,7 +68,6 @@ RUN VERSION="v1.35.3" && ARCH=$(archmap 'arm64' 'amd64') && \
     echo "source <(kubectl completion zsh)" >> /etc/zsh/zshrc
 
 # Install helm (https://github.com/helm/helm/releases)
-# Pin the installer script to the same tag we install for reproducibility.
 RUN VERSION="v4.1.4" && \
     $CURL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/${VERSION}/scripts/get-helm-4 && \
     chmod 700 /tmp/get_helm.sh && /tmp/get_helm.sh --version ${VERSION} && rm -f /tmp/get_helm.sh && \
@@ -148,8 +147,6 @@ RUN VERSION="0.26.1" && ARCH=$(archmap 'aarch64' 'x86_64') && \
     tar -xzC /usr/local/bin --strip-components 1 -f - bat-v${VERSION}-${ARCH}-unknown-linux-musl/bat
 
 # Install kiali-prepare-remote-cluster.sh (https://github.com/kiali/kiali)
-# Pin to a specific commit so image builds are reproducible.
-RUN KIALI_SHA="220965a679679a1fef32490899bc27897f8950bd" && \
-    $CURL -o /usr/local/bin/kiali-prepare-remote-cluster.sh \
-    https://raw.githubusercontent.com/kiali/kiali/${KIALI_SHA}/hack/istio/multicluster/kiali-prepare-remote-cluster.sh && \
+RUN $CURL -o /usr/local/bin/kiali-prepare-remote-cluster.sh \
+    https://raw.githubusercontent.com/kiali/kiali/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh && \
     chmod +x /usr/local/bin/kiali-prepare-remote-cluster.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,12 +11,17 @@ LABEL "org.opencontainers.image.source"="https://github.com/h0tbird/meshlab/tree
 ENV LOCALE=en_US.UTF-8 LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 ENV PATH=/workspaces/meshlab/bin:${PATH}
 
+# Use bash with pipefail so failures in piped commands (curl | tar, etc.) are
+# surfaced instead of silently ignored.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Shared curl flags for all downloads: fail loud on HTTP errors,
 # follow redirects, and retry on transient/HTTP failures.
 ENV CURL="curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 10"
 
 # Architecture helper: archmap <arm64_value> <amd64_value>
-RUN printf '#!/bin/sh\ncase "$(arch)" in aarch64) echo "$1";; x86_64) echo "$2";; esac\n' > /usr/local/bin/archmap && \
+# Exits non-zero on unsupported architectures so broken downloads fail loudly.
+RUN printf '#!/bin/sh\ncase "$(arch)" in aarch64) echo "$1";; x86_64) echo "$2";; *) echo "archmap: unsupported arch $(arch)" >&2; exit 1;; esac\n' > /usr/local/bin/archmap && \
     chmod +x /usr/local/bin/archmap
 
 # Install base packages
@@ -127,7 +132,7 @@ RUN VERSION="0.37.1" && ARCH=$(archmap 'arm64' 'x86_64') && \
     tar -xzC /usr/local/bin tilt && echo "source <(tilt completion zsh)" >> /etc/zsh/zshrc
 
 # Install crane (https://github.com/google/go-containerregistry/releases)
-RUN VERSION="v0.21.5" && ARCH=$(archmap 'arm64' 'i386') && \
+RUN VERSION="v0.21.5" && ARCH=$(archmap 'arm64' 'x86_64') && \
     $CURL https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin crane && echo "source <(crane completion zsh)" >> /etc/zsh/zshrc
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -70,7 +70,7 @@ RUN VERSION="v1.35.3" && ARCH=$(archmap 'arm64' 'amd64') && \
 # Install helm (https://github.com/helm/helm/releases)
 # Pin the installer script to the same tag we install for reproducibility.
 RUN VERSION="v4.1.4" && \
-    $CURL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/${VERSION}/scripts/get-helm-3 && \
+    $CURL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/${VERSION}/scripts/get-helm-4 && \
     chmod 700 /tmp/get_helm.sh && /tmp/get_helm.sh --version ${VERSION} && rm -f /tmp/get_helm.sh && \
     echo "source <(helm completion zsh)" >> /etc/zsh/zshrc
 


### PR DESCRIPTION
Promotes the following commits from fix/devcontainer-dockerfile-p1 into master:

- chore(devcontainer): generate locale, lazy DOCKER_API_VERSION, apt-get cleanups (#39)
- revert(devcontainer): unpin kiali-prepare-remote-cluster.sh for now
- fix(devcontainer): use get-helm-4 installer for helm v4
- fix(devcontainer): pin base image tag and master-sourced scripts
- fix(devcontainer): correct crane arch, add pipefail, fail archmap on unknown arch

PR #39 was inadvertently merged into fix/devcontainer-dockerfile-p1 instead of master; this PR forwards those changes to master.