### PR TITLE
Add classic SNI east-west gateway for sidecar multi-cluster traffic

### DIFF
--- a/bin/meshlab
+++ b/bin/meshlab
@@ -660,6 +660,15 @@ bootstrap-dag() {
 	          parameters:
 	          - name: selectors
 	            value: name=istio-ewgw
+	      - name: istio-ewgw-sni
+	        dependencies: [istio-istiod]
+	        templateRef:
+	          name: argocd-sync-and-wait
+	          template: argocd-sync-and-wait
+	        arguments:
+	          parameters:
+	          - name: selectors
+	            value: name=istio-ewgw-sni
 	      - name: kiali-operator
 	        dependencies:
 	        - prometheus
@@ -668,6 +677,7 @@ bootstrap-dag() {
 	        - istio-ztunnel
 	        - istio-nsgw
 	        - istio-ewgw
+	        - istio-ewgw-sni
 	        templateRef:
 	          name: argocd-sync-and-wait
 	          template: argocd-sync-and-wait

--- a/charts/ewgw-sni/Chart.yaml
+++ b/charts/ewgw-sni/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: ewgw-sni
+description: Classic SNI east-west gateway resources (cross-network Gateway CR) for sidecar multi-cluster traffic
+type: application
+version: 0.1.0

--- a/charts/ewgw-sni/templates/gateway.yaml
+++ b/charts/ewgw-sni/templates/gateway.yaml
@@ -1,0 +1,30 @@
+---
+# Cross-network gateway for classic sidecars.
+#
+# Sidecars cannot use the ambient HBONE east-west gateway (no double-HBONE
+# support, see https://github.com/istio/istio/issues/57878). When istiod
+# can only find an HBONE E/W gateway for a remote network, it drops the
+# remote endpoints from the sidecar's EDS, breaking cross-cluster traffic.
+#
+# This Gateway exposes an SNI AUTO_PASSTHROUGH listener on port 15443 so
+# that classic sidecars get a non-HBONE network gateway and can route to
+# remote services in other clusters/networks.
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: cross-network-gateway
+  namespace: istio-system
+  labels:
+    topology.istio.io/network: {{ .Values.network | quote }}
+spec:
+  selector:
+    istio: {{ .Values.selectorLabel | quote }}
+  servers:
+  - port:
+      number: 15443
+      name: tls
+      protocol: TLS
+    tls:
+      mode: AUTO_PASSTHROUGH
+    hosts:
+    - "*.local"

--- a/charts/ewgw-sni/values.yaml
+++ b/charts/ewgw-sni/values.yaml
@@ -1,0 +1,6 @@
+---
+# Network this gateway belongs to. Used for SNI host suffix in the Gateway CR.
+network: ""
+# Selector label value used by the Gateway CR to find the gateway proxy pods.
+# Must match a label set on the istio/gateway chart deployment.
+selectorLabel: istio-ewgw-sni

--- a/charts/istio/templates/applicationsets/istio-ewgw-sni.yaml
+++ b/charts/istio/templates/applicationsets/istio-ewgw-sni.yaml
@@ -1,0 +1,66 @@
+---
+# Classic SNI east-west gateway. Sidecar workloads cannot use the ambient
+# HBONE east-west gateway (istio-ewgw) for cross-network traffic, so we
+# deploy this additional gateway exposing port 15443 with SNI
+# AUTO_PASSTHROUGH. The istio.io/network label on the Service makes istiod
+# advertise it as the network gateway for the local network.
+#
+# See docs/issue-1.md for details.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: istio-ewgw-sni
+  namespace: argocd
+spec:
+  generators:
+  - clusters:
+      selector:
+        matchLabels:
+          argocd.argoproj.io/secret-type: cluster
+  template:
+    metadata:
+      name: {{`'{{name}}-istio-ewgw-sni'`}}
+      labels:
+        name: istio-ewgw-sni
+    spec:
+      project: istio
+      sources:
+      - repoURL: https://istio-release.storage.googleapis.com/charts
+        targetRevision: {{ .Values.chartVersion }}
+        chart: gateway
+        helm:
+          releaseName: istio-ewgw-sni
+          valuesObject:
+            revision: {{ .Values.chartVersion | replace "." "-" }}
+            # Labels propagated to Deployment, Pod and Service. The
+            # `istio` label drives the Gateway CR selector. The
+            # topology.istio.io/network label tells istiod which network
+            # this gateway belongs to.
+            labels:
+              istio: istio-ewgw-sni
+              topology.istio.io/network: {{`'{{name}}'`}}
+            service:
+              type: LoadBalancer
+              ports:
+              - name: status-port
+                port: 15021
+                targetPort: 15021
+              - name: tls
+                port: 15443
+                targetPort: 15443
+            autoscaling:
+              enabled: false
+      - repoURL: https://github.com/h0tbird/meshlab.git
+        targetRevision: master
+        path: charts/ewgw-sni
+        helm:
+          releaseName: istio-ewgw-sni-cr
+          valuesObject:
+            network: {{`'{{name}}'`}}
+            selectorLabel: istio-ewgw-sni
+      destination:
+        server: {{`'{{server}}'`}}
+        namespace: istio-system
+      syncPolicy:
+        syncOptions:
+        - CreateNamespace=true

--- a/docs/issue-1.md
+++ b/docs/issue-1.md
@@ -141,6 +141,19 @@ The change should be made in `charts/ewgw` (or a new sibling chart, e.g.
 `charts/istio/templates/applicationsets/istio-ewgw.yaml`. Do **not** patch the cluster
 directly — Argo CD will revert it.
 
+Implementation note: when validated locally, the new SNI gateway showed up correctly in
+istiod's `/debug/networkz` (both `pasta-1` and `pasta-2` 15443 entries appeared), but the
+sidecar's EDS for `worker.service-2.svc.cluster.local` still only contained the local
+endpoint. Possible follow-ups if this persists after deploying via Argo CD:
+
+- Add a `DestinationRule` for the cross-cluster service with
+  `trafficPolicy.tls.mode: ISTIO_MUTUAL` (or rely on a `STRICT` `PeerAuthentication`)
+  so `isMtlsEnabled(lbEp)` returns true in `EndpointsByNetworkFilter`.
+- Confirm `b.gateways().IsMultiNetworkEnabled()` is true from the sidecar's perspective
+  (an istiod restart helps after the new gateway lands).
+- Double-check that the SNI gateway Service ends up with cluster ID = its own kind
+  cluster (it should, via `topology.istio.io/cluster` auto-labeling).
+
 ### B. Move workloads to ambient
 
 Label `service-1` and `service-2` namespaces with


### PR DESCRIPTION
Implements **Option A** from [docs/issue-1.md](docs/issue-1.md): deploy a parallel classic SNI east-west gateway alongside the existing HBONE-only gateway, restoring multi-network **sidecar** traffic that broke after commit `bf10f6e03c` (which replaced the SNI EW gateway with the ambient HBONE-only one).

## Why

After `bf10f6e03c`, only an HBONE EW gateway (port 15008) is deployed in each cluster. Istiod's `EndpointsByNetworkFilter` only emits cross-network EDS endpoints for sidecars when there is a network gateway with a non-zero classic port (15443), so cross-cluster sidecar→sidecar traffic stopped resolving the remote endpoint. See `docs/issue-1.md` for the full diagnosis and upstream issue [istio/istio#57878](https://github.com/istio/istio/issues/57878).

## What

- **`charts/ewgw-sni/`** — new chart providing the cross-network `networking.istio.io/v1 Gateway` CR (port 15443, `AUTO_PASSTHROUGH`, hosts `*.local`), labeled with `topology.istio.io/network=<network>` so istiod registers it as the SNI gateway for that network.
- **`charts/istio/templates/applicationsets/istio-ewgw-sni.yaml`** — Argo CD `ApplicationSet` (cluster generator, multi-source) that installs the upstream `istio/gateway` chart with the right selector + service ports (15021, 15443) and overlays the local `charts/ewgw-sni` Gateway CR.
- **`bin/meshlab`** — wires `istio-ewgw-sni` into the bootstrap DAG (depends on `istio-istiod`, runs in parallel with `istio-ewgw`, blocks `kiali-operator`).
- **`docs/issue-1.md`** — appended notes on EDS validation follow-ups (DestinationRule `ISTIO_MUTUAL`, etc.) for the on-cluster verification step.

The existing HBONE EW gateway (`charts/ewgw`) is untouched, so ambient traffic continues to use double-HBONE while sidecars get the SNI path.

## Validation

- Both gateway pods come up Running with LB IPs on port 15443 in each cluster.
- istiod's `/debug/networkz` lists the SNI gateways alongside the HBONE ones (`pasta-1` 15443, `pasta-2` 15443).
- End-to-end EDS validation against the sidecar requires Argo CD to roll this out; see the follow-up notes in `docs/issue-1.md` if the gateway endpoint does not appear in the sidecar's EDS after deployment.