### PR TITLE
Upgrade meshlab components

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -71,7 +71,7 @@ RUN VERSION="v0.31.0" && ARCH=$(archmap 'arm64' 'amd64') && \
     chmod +x /usr/local/bin/kind && echo "source <(kind completion zsh)" >> /etc/zsh/zshrc
 
 # Install kubectl (https://cdn.dl.k8s.io/release/stable.txt)
-RUN VERSION="v1.35.3" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="v1.36.0" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /usr/local/bin/kubectl https://dl.k8s.io/release/${VERSION}/bin/linux/${ARCH}/kubectl && \
     chmod +x /usr/local/bin/kubectl && ln -s /usr/local/bin/kubectl /usr/local/bin/k && \
     echo "source <(kubectl completion zsh)" >> /etc/zsh/zshrc
@@ -83,17 +83,17 @@ RUN VERSION="v4.1.4" && \
     echo "source <(helm completion zsh)" >> /etc/zsh/zshrc
 
 # Install yq (https://github.com/mikefarah/yq/releases)
-RUN VERSION="v4.52.5" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="v4.53.2" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${VERSION}/yq_linux_${ARCH} && \
     chmod +x /usr/local/bin/yq && echo "source <(yq completion zsh)" >> /etc/zsh/zshrc
 
 # Install argocd (https://github.com/argoproj/argo-cd/releases)
-RUN VERSION="v3.3.6" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="v3.3.8" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/${VERSION}/argocd-linux-${ARCH} && \
     chmod +x /usr/local/bin/argocd && echo "source <(argocd completion zsh)" >> /etc/zsh/zshrc
 
 # Install argo (https://github.com/argoproj/argo-workflows/releases)
-RUN VERSION="v4.0.4" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="v4.0.5" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL https://github.com/argoproj/argo-workflows/releases/download/${VERSION}/argo-linux-${ARCH}.gz | gunzip -c > /usr/local/bin/argo && \
     chmod +x /usr/local/bin/argo && echo "source <(argo completion zsh)" >> /etc/zsh/zshrc
 
@@ -115,7 +115,7 @@ RUN VERSION="0.30.2" && ARCH=$(archmap 'arm64' 'amd64') && cd /tmp && \
     echo "source <(step completion zsh)" >> /etc/zsh/zshrc
 
 # Install gh (https://github.com/cli/cli/releases)
-RUN VERSION="2.89.0" && ARCH=$(archmap 'arm64' 'amd64') && cd /tmp && \
+RUN VERSION="2.92.0" && ARCH=$(archmap 'arm64' 'amd64') && cd /tmp && \
     $CURL -O https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_${ARCH}.deb && \
     dpkg -i gh_${VERSION}_linux_${ARCH}.deb && rm -f gh_${VERSION}_linux_${ARCH}.deb && \
     echo "source <(gh completion -s zsh)" >> /etc/zsh/zshrc
@@ -136,7 +136,7 @@ RUN VERSION="1.4.6" && ARCH=$(archmap 'aarch64' 'x86_64') && \
     tar -xjC /usr/local/bin --strip-components 3 -f - ./btop/bin/btop
 
 # Install tilt (https://github.com/tilt-dev/tilt/releases)
-RUN VERSION="0.37.1" && ARCH=$(archmap 'arm64' 'x86_64') && \
+RUN VERSION="0.37.2" && ARCH=$(archmap 'arm64' 'x86_64') && \
     $CURL https://github.com/tilt-dev/tilt/releases/download/v${VERSION}/tilt.${VERSION}.linux.${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin tilt && echo "source <(tilt completion zsh)" >> /etc/zsh/zshrc
 
@@ -146,7 +146,7 @@ RUN VERSION="v0.21.5" && ARCH=$(archmap 'arm64' 'x86_64') && \
     tar -xzC /usr/local/bin crane && echo "source <(crane completion zsh)" >> /etc/zsh/zshrc
 
 # Install grafanactl (https://github.com/grafana/grafanactl/releases)
-RUN VERSION="v0.1.9" && ARCH=$(archmap 'arm64' 'x86_64') && \
+RUN VERSION="v0.1.10" && ARCH=$(archmap 'arm64' 'x86_64') && \
     $CURL https://github.com/grafana/grafanactl/releases/download/${VERSION}/grafanactl_Linux_${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin grafanactl && echo "source <(grafanactl completion zsh)" >> /etc/zsh/zshrc
 

--- a/.github/skills/upgrade-components/SKILL.md
+++ b/.github/skills/upgrade-components/SKILL.md
@@ -79,6 +79,37 @@ RUN VERSION="X.Y.Z" && ARCH=$(archmap 'arm64' 'amd64') && \
 3. **Compare versions** and identify components needing upgrades
 4. **Present summary** showing current vs latest versions before making changes
 5. **Apply updates** preserving the formatting in each file
+6. **If the user asked for a PR**: create a branch, commit, push, and open a PR
+   (see "Creating the PR" below)
+
+## Fetching Latest Versions — Tips
+
+- **GitHub releases — prefer the `gh` CLI over `fetch_webpage`.** It is faster
+  and produces compact output. The terminal tool runs `gh` without a TTY, which
+  triggers the alternate-screen pager and returns empty output. Always disable
+  it explicitly:
+
+  ```bash
+  env GH_FORCE_TTY= GH_PAGER= PAGER=cat NO_COLOR=1 \
+      gh release list -R <owner>/<repo> -L 5
+  ```
+
+  Fetch many repos in a single command using a small shell helper to keep
+  output compact and easy to scan.
+
+- **Helm chart versions — `gh` is also faster than ArtifactHub.** The
+  ArtifactHub HTML pages are extremely large (tens of thousands of tokens of
+  changelog noise). Prefer one of these compact sources:
+  - Chart repo's `index.yaml` (e.g. `curl -sL <repo-url>/index.yaml | yq ...`)
+  - The chart's `Chart.yaml` on GitHub
+  - `gh release list` for the upstream project repo
+  Only fall back to `fetch_webpage` against ArtifactHub when no other source
+  exists.
+
+- **Latest kubectl** lives at `https://dl.k8s.io/release/stable.txt`
+  (note: `cdn.dl.k8s.io` may not resolve from the devcontainer — use `dl.k8s.io`).
+
+- **Latest Go** is in `https://go.dev/dl/?mode=json` (first entry).
 
 ## Formatting Rules
 
@@ -106,8 +137,35 @@ RUN VERSION="v0.32.0" && ARCH=$(archmap 'arm64' 'amd64') && \
 
 - **Prefer stable releases** over pre-release/alpha/beta/RC versions for all components
 - **Stay on current stable series**: When the latest version of a component is a pre-release (RC/alpha/beta), stay on the current stable major.minor series and check for the latest patch version in that series (e.g., if latest Cilium is 1.19.0-rc.1, check for the latest 1.18.x stable release)
+- **`gh release list` shows pre-releases inline** — the `Latest` label marks the
+  newest stable release; do not blindly take the first row. As of 2026-04, both
+  Istio (`1.30.0-beta.0`) and Cilium (`1.20.0-pre.1`) had pre-releases newer
+  than the latest stable.
 - **Note major version upgrades** that may introduce breaking changes
 - **Dependencies**: Some components have compatibility requirements (e.g., Kiali version should be compatible with Istio version)
+
+## Creating the PR
+
+When the user requests a PR:
+
+1. Create a branch off `master`, e.g. `upgrade-components-YYYY-MM`.
+2. Commit the changes with a structured body listing each bumped component
+   (`old -> new`), grouped by file.
+3. Push the branch.
+4. Open the PR with `gh pr create`. **The `istio/istio` repo is added as a
+   workspace remote, so `gh` may pick it as the default upstream and fail with
+   `No commits between istio:master and h0tbird:<branch>`. Always pass
+   `--repo h0tbird/meshlab --base master --head <branch>` explicitly.**
+   Also set `GH_PAGER=cat NO_COLOR=1` so the command does not open the pager.
+
+   ```bash
+   env GH_PAGER=cat NO_COLOR=1 gh pr create \
+     --repo h0tbird/meshlab --base master --head <branch> \
+     --title "Upgrade meshlab components" \
+     --body "..."
+   ```
+
+5. Use the same summary table format from "Output Format" as the PR body.
 
 ## Output Format
 

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -21,18 +21,18 @@ NET_START=$(net_bytes)
 #------------------------------------------------------------------------------
 
 readonly KINDCCM_VERSION='0.10.0'                      # https://github.com/kubernetes-sigs/cloud-provider-kind/releases
-readonly CILIUM_CHART_VERSION='1.19.2'                 # https://artifacthub.io/packages/helm/cilium/cilium
-readonly K8S_GATEWAY_CHART_VERSION='3.6.1'             # https://github.com/k8s-gateway/k8s_gateway/blob/master/charts/k8s-gateway/Chart.yaml
-readonly ARGOCD_CHART_VERSION='9.5.0'                  # https://artifacthub.io/packages/helm/argo-cd-oci/argo-cd
-readonly ARGOWF_CHART_VERSION='1.0.8'                  # https://artifacthub.io/packages/helm/argo/argo-workflows
-readonly PROMETHEUS_CHART_VERSION='29.2.1'             # https://artifacthub.io/packages/helm/prometheus-community/prometheus
+readonly CILIUM_CHART_VERSION='1.19.3'                 # https://artifacthub.io/packages/helm/cilium/cilium
+readonly K8S_GATEWAY_CHART_VERSION='3.7.1'             # https://github.com/k8s-gateway/k8s_gateway/blob/master/charts/k8s-gateway/Chart.yaml
+readonly ARGOCD_CHART_VERSION='9.5.7'                  # https://artifacthub.io/packages/helm/argo-cd-oci/argo-cd
+readonly ARGOWF_CHART_VERSION='1.0.13'                 # https://artifacthub.io/packages/helm/argo/argo-workflows
+readonly PROMETHEUS_CHART_VERSION='29.3.0'             # https://artifacthub.io/packages/helm/prometheus-community/prometheus
 readonly GRAFANA_CHART_VERSION='10.5.15'               # https://artifacthub.io/packages/helm/grafana/grafana
-readonly OTEL_COLLECTOR_CHART_VERSION='0.150.0'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
+readonly OTEL_COLLECTOR_CHART_VERSION='0.152.0'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
 readonly VAULT_CHART_VERSION='0.32.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
 readonly CERT_MANAGER_CHART_VERSION='v1.20.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
 readonly KUBERNETES_REPLICATOR_CHART_VERSION='2.12.3'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
 readonly ISTIO_CHART_VERSION='1.29.2'                  # https://artifacthub.io/packages/helm/istio-official/base
-readonly KIALI_CHART_VERSION='2.24.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
+readonly KIALI_CHART_VERSION='2.25.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
 
 #------------------------------------------------------------------------------
 # [i] Cleanup


### PR DESCRIPTION
## Helm charts (`bin/meshlab`)

| Component | Previous | Latest |
|-----------|----------|--------|
| Cilium | 1.19.2 | **1.19.3** |
| k8s-gateway | 3.6.1 | **3.7.1** |
| Argo CD | 9.5.0 | **9.5.7** |
| Argo Workflows | 1.0.8 | **1.0.13** |
| Prometheus | 29.2.1 | **29.3.0** |
| OpenTelemetry Collector | 0.150.0 | **0.152.0** |
| Kiali Operator | 2.24.0 | **2.25.0** |
| Grafana | 10.5.15 | already latest |
| Vault | 0.32.0 | already latest |
| cert-manager | v1.20.2 | already latest |
| kubernetes-replicator | 2.12.3 | already latest |
| Istio | 1.29.2 | latest stable (1.30.0-beta.0 is pre-release) |
| cloud-provider-kind | 0.10.0 | already latest |

## CLI tools (`.devcontainer/Dockerfile`)

| Tool | Previous | Latest |
|------|----------|--------|
| kubectl | v1.35.3 | **v1.36.0** |
| yq | v4.52.5 | **v4.53.2** |
| argocd | v3.3.6 | **v3.3.8** |
| argo | v4.0.4 | **v4.0.5** |
| gh | 2.89.0 | **2.92.0** |
| tilt | 0.37.1 | **0.37.2** |
| grafanactl | v0.1.9 | **v0.1.10** |
| Go, kind, helm, cilium-cli, istioctl, step, mdbook, swarmctl, btop, crane, bat | — | already latest |

No major-version upgrades; all bumps are minor or patch.