### PR TITLE
feat(ewgw): split east-west gateway into ambient and sidecar variants

### DIFF
--- a/charts/ewgw/templates/gateway-ambient.yaml
+++ b/charts/ewgw/templates/gateway-ambient.yaml
@@ -1,8 +1,13 @@
 ---
+# East-west gateway for ambient-mode workloads.
+#
+# Ambient uses HBONE (HTTP/2 CONNECT tunneling mTLS) on port 15008 with
+# TLS.Mode=Terminate so the ztunnel/waypoint can decapsulate and forward
+# traffic to local workloads.
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: istio-eastwestgateway
+  name: istio-eastwestgateway-ambient
   namespace: istio-system
   labels:
     topology.istio.io/network: {{ .Values.network | quote }}

--- a/charts/ewgw/templates/gateway-sidecar.yaml
+++ b/charts/ewgw/templates/gateway-sidecar.yaml
@@ -1,0 +1,27 @@
+---
+# East-west gateway for sidecar-based workloads.
+#
+# Sidecars cannot use the HBONE listener used by ambient (port 15008,
+# TLS.Mode=Terminate). For multi-network multi-primary discovery, sidecars
+# expect a TLS listener on port 15443 with mode Passthrough so that istiod
+# can publish remote endpoints with SNI auto-passthrough routing.
+#
+# A Service labeled topology.istio.io/network=<network> that listens on
+# port 15443 is the signal pilot uses to register the gateway as a cross-
+# network gateway for sidecar mTLS.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: istio-eastwestgateway-sidecar
+  namespace: istio-system
+  labels:
+    topology.istio.io/network: {{ .Values.network | quote }}
+spec:
+  gatewayClassName: istio-east-west
+  listeners:
+  - name: cross-network
+    hostname: "*.local"
+    port: 15443
+    protocol: TLS
+    tls:
+      mode: Passthrough


### PR DESCRIPTION
## Problem

In a multi-primary, multi-network mesh, traffic from a sidecar-injected pod
to a peer Service in another cluster fails. Inspection of istiod logs
reveals:

```
ads: Workload peer belongs to a different network (pasta-2),
     but no E/W gateway configured, skipping it.
```

The existing east-west gateway listens only on **15008/HBONE/Terminate**,
which is the ambient data-plane protocol. Pilot will only register a
gateway as a cross-network gateway for **sidecars** when it sees a Service
labeled `topology.istio.io/network=<network>` exposing port **15443** (the
`DefaultNetworkGatewayPort` defined in
[`pilot/pkg/serviceregistry/kube/controller/controller.go`](https://github.com/istio/istio/blob/master/pilot/pkg/serviceregistry/kube/controller/controller.go)),
with a TLS listener in **Passthrough** mode (auto-promoted to
`AUTO_PASSTHROUGH` by `IsAutoPassthrough` in
[`pilot/pkg/serviceregistry/kube/conversion.go`](https://github.com/istio/istio/blob/master/pilot/pkg/serviceregistry/kube/conversion.go)).

Because no such listener existed, sidecar EDS for `peer.swarm-sidecar-*`
contained only local endpoints, breaking every sidecar-involved
cross-cluster path.

## Change

The chart now ships two sibling Gateways under the same release, each
purpose-built for one data plane:

| Resource | Listener | Mode | Used by |
|---|---|---|---|
| `istio-eastwestgateway-ambient` | 15008 / HBONE | Terminate (`ISTIO_MUTUAL`) | ztunnel / waypoints |
| `istio-eastwestgateway-sidecar` | 15443 / TLS, hostname `*.local` | Passthrough (auto-passthrough) | sidecars |

Both carry the `topology.istio.io/network` label so istiod registers them
as the cross-network gateway for the respective data plane.

* Rename `charts/ewgw/templates/gateway.yaml` ->
  `charts/ewgw/templates/gateway-ambient.yaml` and rename the underlying
  resource `istio-eastwestgateway` -> `istio-eastwestgateway-ambient`.
* Add `charts/ewgw/templates/gateway-sidecar.yaml` for the sidecar
  PASSTHROUGH listener on 15443.

## Validation

In a two-cluster lab (`kind-pasta-1`, `kind-pasta-2`) the new sidecar
gateway is provisioned by the `istio-east-west` GatewayClass and gets a
LoadBalancer IP on port 15443. After temporarily labeling
`peer.swarm-sidecar-n1` with `istio.io/global=true` (required by the
mesh's `serviceScopeConfigs` filter), `istioctl pc endpoint` on a
sidecar in cluster A now contains the remote cluster's gateway IP:

```
10.51.0.162:8082     outbound|80||peer.swarm-sidecar-n1.svc.cluster.local   (local)
172.18.0.24:15443    outbound|80||peer.swarm-sidecar-n1.svc.cluster.local   (remote)
```

The "no E/W gateway configured" warnings stop and istiod emits
`reloading network gateways`.

## Compatibility / migration notes

* The ambient Gateway is being renamed, so the underlying managed
  Deployment/Service (`istio-eastwestgateway`) is replaced by
  `istio-eastwestgateway-ambient` and gets a **new LoadBalancer IP**.
  Expect a brief ambient cross-cluster blip during the rollout. ArgoCD
  with prune will remove the old objects.
* No remote-secret or trust-domain changes are required.
* Cross-cluster traffic to sidecar-injected services additionally
  requires that those Services be labeled `istio.io/global=true` (and
  receive a multi-cluster DestinationRule) — that's an upstream change
  in [k-swarm](https://github.com/h0tbird/k-swarm) and is out of scope
  here.
