### PR TITLE
fix(ewgw): use istio gatewayClass for sidecar east-west gateway

### DIFF
--- a/charts/ewgw/templates/gateway-sidecar.yaml
+++ b/charts/ewgw/templates/gateway-sidecar.yaml
@@ -15,9 +15,17 @@ metadata:
   name: istio-eastwestgateway-sidecar
   namespace: istio-system
   labels:
+    # Used by pilot to register this Service as the cross-network gateway
+    # for the local network. Combined with port 15443 (DefaultNetworkGatewayPort),
+    # it triggers AUTO_PASSTHROUGH SNI routing for sidecar-to-remote-cluster
+    # mTLS. See pilot/pkg/serviceregistry/kube/conversion.go IsAutoPassthrough.
     topology.istio.io/network: {{ .Values.network | quote }}
 spec:
-  gatewayClassName: istio-east-west
+  # Note: NOT istio-east-west. The istio-east-west GatewayClass only accepts
+  # the ambient HBONE/Terminate listener on 15008 and rejects everything else.
+  # The regular istio GatewayClass is what upstream uses for sidecar east-west
+  # (see istio testdata/eastwest.yaml).
+  gatewayClassName: istio
   listeners:
   - name: cross-network
     hostname: "*.local"


### PR DESCRIPTION
## Problem

After #44 the sidecar east-west `Gateway` deploys as `Degraded`. The
listener is rejected by istiod with:

```
reason: UnsupportedProtocol
message: Expected a single listener on port 15008 with protocol "HBONE"
         and TLS.Mode == Terminate
```

In the Istio version we run (1.29.2), the `istio-east-west` `GatewayClass`
controller (`ManagedGatewayEastWestController`) only accepts the single
ambient HBONE listener on port 15008. Any other listener — including the
TLS Passthrough listener on 15443 we need for sidecar cross-network mTLS —
is refused, so no LB Service is programmed for the sidecar gateway and
remote endpoints never appear in sidecar EDS.

## Fix

Switch the sidecar east-west `Gateway` to `gatewayClassName: istio`. This
is exactly what upstream uses for the sidecar/multi-network gateway in
[`pilot/pkg/config/kube/gateway/testdata/eastwest.yaml`](https://github.com/istio/istio/blob/master/pilot/pkg/config/kube/gateway/testdata/eastwest.yaml).
The auto-passthrough behavior is still triggered because the resulting
`Service` carries:

* `topology.istio.io/network=<network>` (set on the `Gateway` and
  propagated to the managed `Service`)
* a port equal to `DefaultNetworkGatewayPort` (15443)

…which together satisfy
[`IsAutoPassthrough`](https://github.com/istio/istio/blob/master/pilot/pkg/serviceregistry/kube/conversion.go)
in pilot.

Comments were added to the template explaining the constraint so we don't
regress on the next refactor.

## Validation

To be confirmed against the lab after merge:

* `kubectl -n istio-system get gateway istio-eastwestgateway-sidecar`
  reports `PROGRAMMED=True` and the listener `Accepted=True`.
* `istioctl pc endpoint <sidecar-pod>` shows the remote cluster's
  gateway IP on port 15443 for `peer.swarm-sidecar-*` Services that
  carry `istio.io/global=true`.
