### PR TITLE
fix(istiod): enable PILOT_ENABLE_ALPHA_GATEWAY_API for sidecar EW gateway

### DIFF
--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -34,6 +34,11 @@ spec:
                 AUTO_RELOAD_PLUGIN_CERTS: true
                 PILOT_ENABLE_WORKLOAD_ENTRY_AUTOREGISTRATION: true
                 PILOT_ENABLE_WORKLOAD_ENTRY_HEALTHCHECKS: true
+                # Required for the sidecar east-west Gateway: the istio
+                # GatewayClass treats Gateway-API "TLS" listeners as alpha
+                # in 1.29.x, so PASSTHROUGH cross-network listeners on 15443
+                # are otherwise rejected with UnsupportedProtocol.
+                PILOT_ENABLE_ALPHA_GATEWAY_API: "true"
                 ISTIOD_CUSTOM_HOST: {{`'istiod.{{name}}'`}}
                 AMBIENT_ENABLE_MULTI_NETWORK: "true"
                 AMBIENT_ENABLE_BAGGAGE: "true"


### PR DESCRIPTION
## Problem

After #45 the sidecar east-west `Gateway` is `Programmed` (LB Service is
created) but still `Degraded`. The listener is rejected by istiod with:

```
reason: UnsupportedProtocol
message: protocol "TLS" is supported, but only when
         PILOT_ENABLE_ALPHA_GATEWAY_API=true is configured
```

In Istio 1.29.x the `istio` `GatewayClass` treats Gateway-API `TLS`
listeners as alpha. Without the env var, the cross-network PASSTHROUGH
listener on 15443 is dropped, so no virtual host is configured, no
TLSRoute can attach, and istiod still won't publish remote endpoints to
sidecar EDS.

## Fix

Enable `PILOT_ENABLE_ALPHA_GATEWAY_API=true` on istiod via the
ApplicationSet values:

```yaml
pilot:
  env:
    PILOT_ENABLE_ALPHA_GATEWAY_API: "true"
```

This is the same toggle Istio uses for any TLS / TCP / GRPCRoute usage
on the standard `istio` `GatewayClass` in 1.29.x.

## Validation

After istiod rolls out, re-syncing `istio-ewgw` should produce:

```
$ kubectl -n istio-system get gateway istio-eastwestgateway-sidecar -o yaml
status:
  conditions:
  - type: Programmed
    status: "True"
  listeners:
  - name: cross-network
    conditions:
    - type: Accepted
      status: "True"
```

…and istiod should stop logging
`Workload peer belongs to a different network (...), but no E/W gateway configured, skipping it`.
