### PR TITLE
feat(meshlab): add --network-mode={multi,single} deploy-time toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,4 @@ Development Targets
 - Istio sources are cloned to `../istio` if missing. Both repos mount under `/workspaces`.
 - Each workload cluster's Tilt watches `pilot-discovery` and live-updates on change.
 - Run `make istio-binaries` to build new Istio binaries.
+- Cilium *ClusterMesh* always provides pod-to-pod L3 reachability within a cell. The `--network-mode` flag chooses whether Istio piggybacks on that flat network (`single` — no EWGW between sibling clusters) or treats each cluster as its own Istio network and routes between them through the east-west gateway (`multi`).

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,2 @@
-- Think about `clusterDomain`.
-- `swarmctl manifest install` becomes the new root command
-- `swarmctl manifest dump` becomes `swarmctl dump`
+- ISTIO_META_REQUESTED_NETWORK_VIEW
+- AMBIENT_ENABLE_BAGGAGE

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -54,7 +54,7 @@ cleanup() {
   pkill -f 'socat TCP-LISTEN:[0-9]+,fork TCP:' 2>/dev/null || true
 
   # Only delete clusters we created
-  kind delete clusters "${MNGR}" ${CELLS[*]}
+  kind --kubeconfig ~/.kube/config.host delete clusters "${MNGR}" ${CELLS[*]}
 
   rm -rf ./tmp/*
 }

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -45,13 +45,17 @@ cleanup() {
   docker kill $(docker ps -f "name=kindccm" -q) 2>/dev/null || true
   argocd context --delete "${MNGR}" 2>/dev/null || true
 
-  # Tear down whichever of our clusters kind currently knows about.
-  local known=" ${MNGR} ${CELLS[*]} "
+  # Intersection of clusters kind knows about and clusters we own.
+  local known=" ${MNGR} ${CELLS[*]} " ours=()
   while read -r cluster; do
-    [[ " ${known} " == *" ${cluster} "* ]] || continue
-    pkill -f "tilt up --context kind-${cluster}" 2>/dev/null || true
-    kind --kubeconfig ~/.kube/config.host delete cluster --name "${cluster}" 2>/dev/null || true
+    [[ " ${known} " == *" ${cluster} "* ]] && ours+=("${cluster}")
   done < <(kind --kubeconfig ~/.kube/config.host get clusters 2>/dev/null)
+
+  # Stop tilt for each, then delete them all in one kind invocation.
+  for cluster in "${ours[@]}"; do
+    pkill -f "tilt up --context kind-${cluster}" 2>/dev/null || true
+  done
+  (( ${#ours[@]} )) && kind --kubeconfig ~/.kube/config.host delete clusters "${ours[@]}" 2>/dev/null || true
 
   # Only kill socat tunnels we started from publish()
   pkill -f 'socat TCP-LISTEN:[0-9]+,fork TCP:' 2>/dev/null || true

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -45,18 +45,16 @@ cleanup() {
   docker kill $(docker ps -f "name=kindccm" -q) 2>/dev/null || true
   argocd context --delete "${MNGR}" 2>/dev/null || true
 
-  # Kill tilt instances we started (one per workload cluster)
-  for cluster in $(clusters_to_clean); do
+  # Tear down whichever of our clusters kind currently knows about.
+  local known=" ${MNGR} ${CELLS[*]} "
+  while read -r cluster; do
+    [[ " ${known} " == *" ${cluster} "* ]] || continue
     pkill -f "tilt up --context kind-${cluster}" 2>/dev/null || true
-  done
+    kind --kubeconfig ~/.kube/config.host delete cluster --name "${cluster}" 2>/dev/null || true
+  done < <(kind --kubeconfig ~/.kube/config.host get clusters 2>/dev/null)
 
   # Only kill socat tunnels we started from publish()
   pkill -f 'socat TCP-LISTEN:[0-9]+,fork TCP:' 2>/dev/null || true
-
-  # Delete the kind clusters we provisioned
-  for cluster in $(clusters_to_clean); do
-    kind --kubeconfig ~/.kube/config.host delete cluster --name "${cluster}" 2>/dev/null || true
-  done
 
   rm -rf ./tmp/* ./tmp/.[!.]* 2>/dev/null || true
 }
@@ -944,7 +942,6 @@ parse_create_args() {
     --network-mode) _oneof "${2:-}" multi single; NETWORK_MODE=$2; shift 2 ;;
     *) echo "unknown create flag: $1" >&2; exit 1 ;;
   esac; done
-  save_state
 }
 
 # Parse `run` arguments: a required section name followed by optional flags.
@@ -959,7 +956,7 @@ parse_run_args() {
 # Main case statement for top-level subcommands. Each subcommand is responsible for validating its own arguments (if any).
 case "${1:-}" in
   create) shift; parse_create_args "$@" ;;
-  delete) load_state || true; cleanup; exit 0 ;;
+  delete) cleanup; exit 0 ;;
   watch) watch --color 'ml short'; exit 0 ;;
   run) shift; parse_run_args "$@"; measure "${SECTION}"; exit 0 ;;
   list) printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -874,7 +874,7 @@ _meshlab() {
   local state
 
   subcommands=(
-    'create:Create clusters and run all sections (optional WLCNT)'
+    'create:Create clusters and run all sections (optional WLCNT and --network-mode)'
     'delete:Tear down clusters and clean up'
     'watch:Watch cluster state via `ml short`'
     'list:List all available sections'
@@ -931,32 +931,35 @@ EOF
 # [i] Validate the command line arguments
 #------------------------------------------------------------------------------
 
-# Strip global flags (currently just --network-mode) before the subcommand so
-# the existing positional dispatch below stays unchanged. Default mode is
-# `multi` to preserve backwards compatibility with PR #28.
-export NETWORK_MODE="multi"
-ARGS=()
-while (($#)); do
-  case "$1" in
-    --network-mode=*) NETWORK_MODE="${1#*=}"; shift ;;
-    --network-mode)   NETWORK_MODE="${2:?--network-mode requires a value}"; shift 2 ;;
-    *)                ARGS+=("$1"); shift ;;
+# `create` accepts an optional positional [count] and an optional
+# `--network-mode <multi|single>` flag (default `multi`, matching PR #28).
+parse_create_args() {
+  export WLCNT=1
+  export NETWORK_MODE="multi"
+  while (($#)); do
+    case "$1" in
+      --network-mode)
+        NETWORK_MODE="${2:?--network-mode requires a value}"; shift 2 ;;
+      [0-9]*)
+        WLCNT="$1"; shift ;;
+      *)
+        echo "Unknown create argument: $1" >&2; exit 1 ;;
+    esac
+  done
+  case "${NETWORK_MODE}" in
+    multi|single) ;;
+    *) echo "Invalid --network-mode '${NETWORK_MODE}' (expected: multi|single)" >&2; exit 1 ;;
   esac
-done
-case "${NETWORK_MODE}" in
-  multi|single) ;;
-  *) echo "Invalid --network-mode '${NETWORK_MODE}' (expected: multi|single)" >&2; exit 1 ;;
-esac
-set -- "${ARGS[@]}"
+}
 
 case "${1:-}" in
-  create) export WLCNT="${2:-1}" ;;
+  create) shift; parse_create_args "$@" ;;
   delete) cleanup; exit 0 ;;
   watch) watch --color 'ml short'; exit 0 ;;
   run)  export WLCNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
   list) printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;
   completion) completion "${2:-}"; exit 0 ;;
-  *)    echo "Usage: $(basename "$0") [--network-mode=multi|single] <create|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
+  *)    echo "Usage: $(basename "$0") <create [count] [--network-mode multi|single]|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
 esac
 
 #------------------------------------------------------------------------------

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -944,17 +944,19 @@ export CELL_COUNT=1
 export NETWORK_MODE=multi
 
 # Tiny validators (assert, with a friendly error).
-_uint()  { [[ "$1" =~ ^[0-9]+$ ]]            || { echo "expected non-negative integer, got '$1'" >&2; exit 1; }; }
+_uint()  { [[ "$1" =~ ^[0-9]+$ ]] || { echo "expected non-negative integer, got '$1'" >&2; exit 1; }; }
 _oneof() { local v=$1; shift; [[ " $* " == *" $v "* ]] || { echo "expected one of: $*, got '$v'" >&2; exit 1; }; }
 
+# Parse `create` flags (called by the main case statement below). Flags must be passed before any positional arguments.
 parse_create_args() {
   while (($#)); do case "$1" in
-    --cell-count)   _uint  "${2:-}";              CELL_COUNT=$2;   shift 2 ;;
+    --cell-count)   _uint  "${2:-}"; CELL_COUNT=$2; shift 2 ;;
     --network-mode) _oneof "${2:-}" multi single; NETWORK_MODE=$2; shift 2 ;;
     *) echo "unknown create flag: $1" >&2; exit 1 ;;
   esac; done
 }
 
+# Main case statement for top-level subcommands. Each subcommand is responsible for validating its own arguments (if any).
 case "${1:-}" in
   create)     shift; parse_create_args "$@" ;;
   delete)     cleanup; exit 0 ;;

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -452,7 +452,7 @@ install-applicationsets() {
   helm template ./charts/vault --set "chartVersion=${VAULT_CHART_VERSION}" | k0 "${ssa[@]}" &
   helm template ./charts/cert-manager --set "chartVersion=${CERT_MANAGER_CHART_VERSION}" | k0 "${ssa[@]}" &
   helm template ./charts/kubernetes-replicator --set "chartVersion=${KUBERNETES_REPLICATOR_CHART_VERSION}" | k0 "${ssa[@]}" &
-  helm template ./charts/istio --set "chartVersion=${ISTIO_CHART_VERSION}" | k0 "${ssa[@]}" &
+  helm template ./charts/istio --set "chartVersion=${ISTIO_CHART_VERSION}" --set "networkMode=${NETWORK_MODE}" | k0 "${ssa[@]}" &
   helm template ./charts/kiali --set "chartVersion=${KIALI_CHART_VERSION}" | k0 "${ssa[@]}" &
   join
 }; SECTIONS+=( install-applicationsets )
@@ -931,6 +931,24 @@ EOF
 # [i] Validate the command line arguments
 #------------------------------------------------------------------------------
 
+# Strip global flags (currently just --network-mode) before the subcommand so
+# the existing positional dispatch below stays unchanged. Default mode is
+# `multi` to preserve backwards compatibility with PR #28.
+export NETWORK_MODE="multi"
+ARGS=()
+while (($#)); do
+  case "$1" in
+    --network-mode=*) NETWORK_MODE="${1#*=}"; shift ;;
+    --network-mode)   NETWORK_MODE="${2:?--network-mode requires a value}"; shift 2 ;;
+    *)                ARGS+=("$1"); shift ;;
+  esac
+done
+case "${NETWORK_MODE}" in
+  multi|single) ;;
+  *) echo "Invalid --network-mode '${NETWORK_MODE}' (expected: multi|single)" >&2; exit 1 ;;
+esac
+set -- "${ARGS[@]}"
+
 case "${1:-}" in
   create) export WLCNT="${2:-1}" ;;
   delete) cleanup; exit 0 ;;
@@ -938,7 +956,7 @@ case "${1:-}" in
   run)  export WLCNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
   list) printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;
   completion) completion "${2:-}"; exit 0 ;;
-  *)    echo "Usage: $(basename "$0") <create|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
+  *)    echo "Usage: $(basename "$0") [--network-mode=multi|single] <create|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
 esac
 
 #------------------------------------------------------------------------------

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -878,7 +878,7 @@ _meshlab() {
     'delete:Tear down clusters and clean up'
     'watch:Watch cluster state via `ml short`'
     'list:List all available sections'
-    'run:Run a single section (run <section> [count])'
+    'run:Run a single section (run <section> [--cell-count N])'
     'completion:Print shell completion script (completion <shell>)'
   )
 
@@ -886,6 +886,7 @@ _meshlab() {
     '1: :->cmd' \
     '2: :->arg2' \
     '3: :->arg3' \
+    '4: :->arg4' \
     && return
 
   case $state in
@@ -911,14 +912,25 @@ _meshlab() {
     arg3)
       case ${words[2]} in
         run)
-          counts=(1 2)
-          _describe -t counts 'workload count' counts
+          flags=(--cell-count)
+          _describe -t flags 'run flag' flags
           ;;
         create)
           case ${words[3]} in
             --cell-count)   counts=(1 2);   _describe -t counts 'count' counts ;;
             --network-mode) modes=(multi single); _describe -t modes 'mode' modes ;;
           esac
+          ;;
+      esac
+      ;;
+    arg4)
+      case ${words[2]} in
+        run)
+          [[ ${words[3]} == --cell-count ]] && { counts=(1 2); _describe -t counts 'count' counts; }
+          ;;
+        create)
+          flags=(--cell-count --network-mode)
+          _describe -t flags 'create flag' flags
           ;;
       esac
       ;;
@@ -956,15 +968,24 @@ parse_create_args() {
   esac; done
 }
 
+# Parse `run` arguments: a required section name followed by optional flags.
+parse_run_args() {
+  SECTION="${1:?Usage: meshlab run <section> [--cell-count N]}"; shift
+  while (($#)); do case "$1" in
+    --cell-count) _uint "${2:-}"; CELL_COUNT=$2; shift 2 ;;
+    *) echo "unknown run flag: $1" >&2; exit 1 ;;
+  esac; done
+}
+
 # Main case statement for top-level subcommands. Each subcommand is responsible for validating its own arguments (if any).
 case "${1:-}" in
   create) shift; parse_create_args "$@" ;;
   delete) cleanup; exit 0 ;;
   watch) watch --color 'ml short'; exit 0 ;;
-  run) export CELL_COUNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
+  run) shift; parse_run_args "$@"; measure "${SECTION}"; exit 0 ;;
   list) printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;
   completion) completion "${2:-}"; exit 0 ;;
-  *) echo "Usage: $(basename "$0") <create [--cell-count N] [--network-mode multi|single]|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
+  *) echo "Usage: $(basename "$0") <create [--cell-count N] [--network-mode multi|single]|delete|watch|list|run SECTION [--cell-count N]|completion <shell>>"; exit 1 ;;
 esac
 
 #------------------------------------------------------------------------------

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -45,22 +45,18 @@ cleanup() {
   docker kill $(docker ps -f "name=kindccm" -q) 2>/dev/null || true
   argocd context --delete "${MNGR}" 2>/dev/null || true
 
-  # Intersection of clusters kind knows about and clusters we own.
-  local known=" ${MNGR} ${CELLS[*]} " ours=()
-  while read -r cluster; do
-    [[ " ${known} " == *" ${cluster} "* ]] && ours+=("${cluster}")
-  done < <(kind --kubeconfig ~/.kube/config.host get clusters 2>/dev/null)
-
-  # Stop tilt for each, then delete them all in one kind invocation.
-  for cluster in "${ours[@]}"; do
+  # Only kill tilt instances we started (one per workload cluster)
+  for cluster in $(clusters); do
     pkill -f "tilt up --context kind-${cluster}" 2>/dev/null || true
   done
-  (( ${#ours[@]} )) && kind --kubeconfig ~/.kube/config.host delete clusters "${ours[@]}" 2>/dev/null || true
 
   # Only kill socat tunnels we started from publish()
   pkill -f 'socat TCP-LISTEN:[0-9]+,fork TCP:' 2>/dev/null || true
 
-  rm -rf ./tmp/* ./tmp/.[!.]* 2>/dev/null || true
+  # Only delete clusters we created
+  kind delete clusters "${MNGR}" ${CELLS[*]}
+
+  rm -rf ./tmp/*
 }
 
 #------------------------------------------------------------------------------

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -45,20 +45,20 @@ cleanup() {
   docker kill $(docker ps -f "name=kindccm" -q) 2>/dev/null || true
   argocd context --delete "${MNGR}" 2>/dev/null || true
 
-  # Only kill tilt instances we started (one per workload cluster, across every cell)
-  for cluster in $(every_cluster); do
+  # Kill tilt instances we started (one per workload cluster)
+  for cluster in $(clusters_to_clean); do
     pkill -f "tilt up --context kind-${cluster}" 2>/dev/null || true
   done
 
   # Only kill socat tunnels we started from publish()
   pkill -f 'socat TCP-LISTEN:[0-9]+,fork TCP:' 2>/dev/null || true
 
-  # Only delete clusters we created (across every cell, regardless of CELL_COUNT)
-  for cluster in $(every_cluster); do
+  # Delete the kind clusters we provisioned
+  for cluster in $(clusters_to_clean); do
     kind --kubeconfig ~/.kube/config.host delete cluster --name "${cluster}" 2>/dev/null || true
   done
 
-  rm -rf ./tmp/*
+  rm -rf ./tmp/* ./tmp/.[!.]* 2>/dev/null || true
 }
 
 #------------------------------------------------------------------------------
@@ -944,6 +944,7 @@ parse_create_args() {
     --network-mode) _oneof "${2:-}" multi single; NETWORK_MODE=$2; shift 2 ;;
     *) echo "unknown create flag: $1" >&2; exit 1 ;;
   esac; done
+  save_state
 }
 
 # Parse `run` arguments: a required section name followed by optional flags.
@@ -958,7 +959,7 @@ parse_run_args() {
 # Main case statement for top-level subcommands. Each subcommand is responsible for validating its own arguments (if any).
 case "${1:-}" in
   create) shift; parse_create_args "$@" ;;
-  delete) cleanup; exit 0 ;;
+  delete) load_state || true; cleanup; exit 0 ;;
   watch) watch --color 'ml short'; exit 0 ;;
   run) shift; parse_run_args "$@"; measure "${SECTION}"; exit 0 ;;
   list) printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -939,38 +939,28 @@ EOF
 # [i] Validate the command line arguments
 #------------------------------------------------------------------------------
 
-# `create` accepts two optional flags:
-#   --cell-count <N>               number of workload cells (default 1)
-#   --network-mode <multi|single>  Istio network topology (default multi)
-parse_create_args() {
-  export CELL_COUNT=1
-  export NETWORK_MODE="multi"
-  while (($#)); do
-    case "$1" in
-      --cell-count)
-        CELL_COUNT="${2:?--cell-count requires a value}"; shift 2 ;;
-      --network-mode)
-        NETWORK_MODE="${2:?--network-mode requires a value}"; shift 2 ;;
-      *)
-        echo "Unknown create argument: $1" >&2; exit 1 ;;
-    esac
-  done
-  [[ "${CELL_COUNT}" =~ ^[0-9]+$ ]] \
-    || { echo "Invalid --cell-count '${CELL_COUNT}' (expected a non-negative integer)" >&2; exit 1; }
-  case "${NETWORK_MODE}" in
-    multi|single) ;;
-    *) echo "Invalid --network-mode '${NETWORK_MODE}' (expected: multi|single)" >&2; exit 1 ;;
-  esac
-}
+# Defaults for `create` flags.
+export CELL_COUNT=1
+export NETWORK_MODE=multi
+
+# Tiny validators (assert, with a friendly error).
+_uint()  { [[ "$1" =~ ^[0-9]+$ ]]            || { echo "expected non-negative integer, got '$1'" >&2; exit 1; }; }
+_oneof() { local v=$1; shift; [[ " $* " == *" $v "* ]] || { echo "expected one of: $*, got '$v'" >&2; exit 1; }; }
 
 case "${1:-}" in
-  create) shift; parse_create_args "$@" ;;
-  delete) cleanup; exit 0 ;;
-  watch) watch --color 'ml short'; exit 0 ;;
-  run)  export CELL_COUNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
-  list) printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;
+  create)
+    shift
+    while (($#)); do case "$1" in
+      --cell-count)   _uint  "${2:-}";              CELL_COUNT=$2;   shift 2 ;;
+      --network-mode) _oneof "${2:-}" multi single; NETWORK_MODE=$2; shift 2 ;;
+      *) echo "unknown create flag: $1" >&2; exit 1 ;;
+    esac; done ;;
+  delete)     cleanup; exit 0 ;;
+  watch)      watch --color 'ml short'; exit 0 ;;
+  run)        export CELL_COUNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
+  list)       printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;
   completion) completion "${2:-}"; exit 0 ;;
-  *)    echo "Usage: $(basename "$0") <create [--cell-count N] [--network-mode multi|single]|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
+  *) echo "Usage: $(basename "$0") <create [--cell-count N] [--network-mode multi|single]|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
 esac
 
 #------------------------------------------------------------------------------

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -887,11 +887,16 @@ _meshlab() {
     return
   fi
 
-  case ${words[2]} in
+  # Shift past the subcommand so inner _arguments sees a clean command line.
+  local sub=${words[2]}
+  (( CURRENT-- ))
+  words=( "${words[1]}" "${words[@]:2}" )
+
+  case $sub in
     create)
       _arguments \
-        '--cell-count[Number of workload cells]:count:(1 2)' \
-        '--network-mode[Istio network topology]:mode:(multi single)'
+        '*--cell-count[Number of workload cells]:count:(1 2)' \
+        '*--network-mode[Istio network topology]:mode:(multi single)'
       ;;
     run)
       _arguments \

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -958,11 +958,11 @@ parse_create_args() {
 
 # Main case statement for top-level subcommands. Each subcommand is responsible for validating its own arguments (if any).
 case "${1:-}" in
-  create)     shift; parse_create_args "$@" ;;
-  delete)     cleanup; exit 0 ;;
-  watch)      watch --color 'ml short'; exit 0 ;;
-  run)        export CELL_COUNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
-  list)       printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;
+  create) shift; parse_create_args "$@" ;;
+  delete) cleanup; exit 0 ;;
+  watch) watch --color 'ml short'; exit 0 ;;
+  run) export CELL_COUNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
+  list) printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;
   completion) completion "${2:-}"; exit 0 ;;
   *) echo "Usage: $(basename "$0") <create [--cell-count N] [--network-mode multi|single]|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
 esac

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -874,7 +874,7 @@ _meshlab() {
   local state
 
   subcommands=(
-    'create:Create clusters and run all sections (optional --count and --network-mode)'
+    'create:Create clusters and run all sections (optional --cell-count and --network-mode)'
     'delete:Tear down clusters and clean up'
     'watch:Watch cluster state via `ml short`'
     'list:List all available sections'
@@ -899,7 +899,7 @@ _meshlab() {
           _describe -t sections 'section' sections
           ;;
         create)
-          flags=(--count --network-mode)
+          flags=(--cell-count --network-mode)
           _describe -t flags 'create flag' flags
           ;;
         completion)
@@ -916,7 +916,7 @@ _meshlab() {
           ;;
         create)
           case ${words[3]} in
-            --count)        counts=(1 2);   _describe -t counts 'count' counts ;;
+            --cell-count)   counts=(1 2);   _describe -t counts 'count' counts ;;
             --network-mode) modes=(multi single); _describe -t modes 'mode' modes ;;
           esac
           ;;
@@ -940,23 +940,23 @@ EOF
 #------------------------------------------------------------------------------
 
 # `create` accepts two optional flags:
-#   --count <N>                  number of workload cells (default 1)
+#   --cell-count <N>               number of workload cells (default 1)
 #   --network-mode <multi|single>  Istio network topology (default multi)
 parse_create_args() {
-  export WLCNT=1
+  export CELL_COUNT=1
   export NETWORK_MODE="multi"
   while (($#)); do
     case "$1" in
-      --count)
-        WLCNT="${2:?--count requires a value}"; shift 2 ;;
+      --cell-count)
+        CELL_COUNT="${2:?--cell-count requires a value}"; shift 2 ;;
       --network-mode)
         NETWORK_MODE="${2:?--network-mode requires a value}"; shift 2 ;;
       *)
         echo "Unknown create argument: $1" >&2; exit 1 ;;
     esac
   done
-  [[ "${WLCNT}" =~ ^[0-9]+$ ]] \
-    || { echo "Invalid --count '${WLCNT}' (expected a non-negative integer)" >&2; exit 1; }
+  [[ "${CELL_COUNT}" =~ ^[0-9]+$ ]] \
+    || { echo "Invalid --cell-count '${CELL_COUNT}' (expected a non-negative integer)" >&2; exit 1; }
   case "${NETWORK_MODE}" in
     multi|single) ;;
     *) echo "Invalid --network-mode '${NETWORK_MODE}' (expected: multi|single)" >&2; exit 1 ;;
@@ -967,10 +967,10 @@ case "${1:-}" in
   create) shift; parse_create_args "$@" ;;
   delete) cleanup; exit 0 ;;
   watch) watch --color 'ml short'; exit 0 ;;
-  run)  export WLCNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
+  run)  export CELL_COUNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
   list) printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;
   completion) completion "${2:-}"; exit 0 ;;
-  *)    echo "Usage: $(basename "$0") <create [--count N] [--network-mode multi|single]|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
+  *)    echo "Usage: $(basename "$0") <create [--cell-count N] [--network-mode multi|single]|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
 esac
 
 #------------------------------------------------------------------------------

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -947,14 +947,16 @@ export NETWORK_MODE=multi
 _uint()  { [[ "$1" =~ ^[0-9]+$ ]]            || { echo "expected non-negative integer, got '$1'" >&2; exit 1; }; }
 _oneof() { local v=$1; shift; [[ " $* " == *" $v "* ]] || { echo "expected one of: $*, got '$v'" >&2; exit 1; }; }
 
+parse_create_args() {
+  while (($#)); do case "$1" in
+    --cell-count)   _uint  "${2:-}";              CELL_COUNT=$2;   shift 2 ;;
+    --network-mode) _oneof "${2:-}" multi single; NETWORK_MODE=$2; shift 2 ;;
+    *) echo "unknown create flag: $1" >&2; exit 1 ;;
+  esac; done
+}
+
 case "${1:-}" in
-  create)
-    shift
-    while (($#)); do case "$1" in
-      --cell-count)   _uint  "${2:-}";              CELL_COUNT=$2;   shift 2 ;;
-      --network-mode) _oneof "${2:-}" multi single; NETWORK_MODE=$2; shift 2 ;;
-      *) echo "unknown create flag: $1" >&2; exit 1 ;;
-    esac; done ;;
+  create)     shift; parse_create_args "$@" ;;
   delete)     cleanup; exit 0 ;;
   watch)      watch --color 'ml short'; exit 0 ;;
   run)        export CELL_COUNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -871,7 +871,7 @@ completion() {
 
 _meshlab() {
   local -a subcommands sections
-  local curcontext=$curcontext state line ret=1
+  local state
 
   subcommands=(
     'create:Create clusters and run all sections (optional --cell-count and --network-mode)'
@@ -882,40 +882,32 @@ _meshlab() {
     'completion:Print shell completion script (completion <shell>)'
   )
 
-  _arguments -C \
-    '1: :->cmd' \
-    '*::: :->args' \
-    && ret=0
+  if (( CURRENT == 2 )); then
+    _describe -t commands 'meshlab subcommand' subcommands
+    return
+  fi
 
-  case $state in
-    cmd)
-      _describe -t commands 'meshlab subcommand' subcommands && ret=0
+  case ${words[2]} in
+    create)
+      _arguments \
+        '--cell-count[Number of workload cells]:count:(1 2)' \
+        '--network-mode[Istio network topology]:mode:(multi single)'
       ;;
-    args)
-      case $words[1] in
-        create)
-          _arguments \
-            '--cell-count[Number of workload cells]:count:(1 2)' \
-            '--network-mode[Istio network topology]:mode:(multi single)' \
-            && ret=0
-          ;;
-        run)
-          if (( CURRENT == 2 )); then
-            sections=(${(f)"$(command meshlab list 2>/dev/null)"})
-            _describe -t sections 'section' sections && ret=0
-          else
-            _arguments \
-              '--cell-count[Number of workload cells]:count:(1 2)' \
-              && ret=0
-          fi
-          ;;
-        completion)
-          (( CURRENT == 2 )) && { _values 'shell' zsh && ret=0; }
+    run)
+      _arguments \
+        '1:section:->section' \
+        '*--cell-count[Number of workload cells]:count:(1 2)'
+      case $state in
+        section)
+          sections=(${(f)"$(command meshlab list 2>/dev/null)"})
+          _describe -t sections 'section' sections
           ;;
       esac
       ;;
+    completion)
+      _arguments '1:shell:(zsh)'
+      ;;
   esac
-  return ret
 }
 
 compdef _meshlab meshlab

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -870,8 +870,8 @@ completion() {
 # the SECTIONS array defined in the script itself.
 
 _meshlab() {
-  local -a subcommands sections counts shells modes flags
-  local state
+  local -a subcommands sections
+  local curcontext=$curcontext state line ret=1
 
   subcommands=(
     'create:Create clusters and run all sections (optional --cell-count and --network-mode)'
@@ -884,57 +884,38 @@ _meshlab() {
 
   _arguments -C \
     '1: :->cmd' \
-    '2: :->arg2' \
-    '3: :->arg3' \
-    '4: :->arg4' \
-    && return
+    '*::: :->args' \
+    && ret=0
 
   case $state in
     cmd)
-      _describe -t commands 'meshlab subcommand' subcommands
+      _describe -t commands 'meshlab subcommand' subcommands && ret=0
       ;;
-    arg2)
-      case ${words[2]} in
-        run)
-          sections=(${(f)"$(command meshlab list 2>/dev/null)"})
-          _describe -t sections 'section' sections
-          ;;
+    args)
+      case $words[1] in
         create)
-          flags=(--cell-count --network-mode)
-          _describe -t flags 'create flag' flags
+          _arguments \
+            '--cell-count[Number of workload cells]:count:(1 2)' \
+            '--network-mode[Istio network topology]:mode:(multi single)' \
+            && ret=0
+          ;;
+        run)
+          if (( CURRENT == 2 )); then
+            sections=(${(f)"$(command meshlab list 2>/dev/null)"})
+            _describe -t sections 'section' sections && ret=0
+          else
+            _arguments \
+              '--cell-count[Number of workload cells]:count:(1 2)' \
+              && ret=0
+          fi
           ;;
         completion)
-          shells=(zsh)
-          _describe -t shells 'shell' shells
-          ;;
-      esac
-      ;;
-    arg3)
-      case ${words[2]} in
-        run)
-          flags=(--cell-count)
-          _describe -t flags 'run flag' flags
-          ;;
-        create)
-          case ${words[3]} in
-            --cell-count)   counts=(1 2);   _describe -t counts 'count' counts ;;
-            --network-mode) modes=(multi single); _describe -t modes 'mode' modes ;;
-          esac
-          ;;
-      esac
-      ;;
-    arg4)
-      case ${words[2]} in
-        run)
-          [[ ${words[3]} == --cell-count ]] && { counts=(1 2); _describe -t counts 'count' counts; }
-          ;;
-        create)
-          flags=(--cell-count --network-mode)
-          _describe -t flags 'create flag' flags
+          (( CURRENT == 2 )) && { _values 'shell' zsh && ret=0; }
           ;;
       esac
       ;;
   esac
+  return ret
 }
 
 compdef _meshlab meshlab

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -870,11 +870,11 @@ completion() {
 # the SECTIONS array defined in the script itself.
 
 _meshlab() {
-  local -a subcommands sections counts shells
+  local -a subcommands sections counts shells modes flags
   local state
 
   subcommands=(
-    'create:Create clusters and run all sections (optional WLCNT and --network-mode)'
+    'create:Create clusters and run all sections (optional --count and --network-mode)'
     'delete:Tear down clusters and clean up'
     'watch:Watch cluster state via `ml short`'
     'list:List all available sections'
@@ -899,8 +899,8 @@ _meshlab() {
           _describe -t sections 'section' sections
           ;;
         create)
-          counts=(1 2)
-          _describe -t counts 'workload count' counts
+          flags=(--count --network-mode)
+          _describe -t flags 'create flag' flags
           ;;
         completion)
           shells=(zsh)
@@ -909,10 +909,18 @@ _meshlab() {
       esac
       ;;
     arg3)
-      if [[ ${words[2]} == run ]]; then
-        counts=(1 2)
-        _describe -t counts 'workload count' counts
-      fi
+      case ${words[2]} in
+        run)
+          counts=(1 2)
+          _describe -t counts 'workload count' counts
+          ;;
+        create)
+          case ${words[3]} in
+            --count)        counts=(1 2);   _describe -t counts 'count' counts ;;
+            --network-mode) modes=(multi single); _describe -t modes 'mode' modes ;;
+          esac
+          ;;
+      esac
       ;;
   esac
 }
@@ -931,21 +939,24 @@ EOF
 # [i] Validate the command line arguments
 #------------------------------------------------------------------------------
 
-# `create` accepts an optional positional [count] and an optional
-# `--network-mode <multi|single>` flag (default `multi`, matching PR #28).
+# `create` accepts two optional flags:
+#   --count <N>                  number of workload cells (default 1)
+#   --network-mode <multi|single>  Istio network topology (default multi)
 parse_create_args() {
   export WLCNT=1
   export NETWORK_MODE="multi"
   while (($#)); do
     case "$1" in
+      --count)
+        WLCNT="${2:?--count requires a value}"; shift 2 ;;
       --network-mode)
         NETWORK_MODE="${2:?--network-mode requires a value}"; shift 2 ;;
-      [0-9]*)
-        WLCNT="$1"; shift ;;
       *)
         echo "Unknown create argument: $1" >&2; exit 1 ;;
     esac
   done
+  [[ "${WLCNT}" =~ ^[0-9]+$ ]] \
+    || { echo "Invalid --count '${WLCNT}' (expected a non-negative integer)" >&2; exit 1; }
   case "${NETWORK_MODE}" in
     multi|single) ;;
     *) echo "Invalid --network-mode '${NETWORK_MODE}' (expected: multi|single)" >&2; exit 1 ;;
@@ -959,7 +970,7 @@ case "${1:-}" in
   run)  export WLCNT="${3:-1}"; measure "${2:?Usage: $0 run <section> [count]}"; exit 0 ;;
   list) printf '%s\n' "${SECTIONS[@]}"; exit 0 ;;
   completion) completion "${2:-}"; exit 0 ;;
-  *)    echo "Usage: $(basename "$0") <create [count] [--network-mode multi|single]|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
+  *)    echo "Usage: $(basename "$0") <create [--count N] [--network-mode multi|single]|delete|watch|list|run SECTION [count]|completion <shell>>"; exit 1 ;;
 esac
 
 #------------------------------------------------------------------------------

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -45,16 +45,16 @@ cleanup() {
   docker kill $(docker ps -f "name=kindccm" -q) 2>/dev/null || true
   argocd context --delete "${MNGR}" 2>/dev/null || true
 
-  # Only kill tilt instances we started (one per workload cluster)
-  for cluster in $(clusters); do
+  # Only kill tilt instances we started (one per workload cluster, across every cell)
+  for cluster in $(every_cluster); do
     pkill -f "tilt up --context kind-${cluster}" 2>/dev/null || true
   done
 
   # Only kill socat tunnels we started from publish()
   pkill -f 'socat TCP-LISTEN:[0-9]+,fork TCP:' 2>/dev/null || true
 
-  # Only delete clusters we created
-  for cluster in $(all_clusters); do
+  # Only delete clusters we created (across every cell, regardless of CELL_COUNT)
+  for cluster in $(every_cluster); do
     kind --kubeconfig ~/.kube/config.host delete cluster --name "${cluster}" 2>/dev/null || true
   done
 

--- a/charts/istio/templates/applicationsets/istio-base.yaml
+++ b/charts/istio/templates/applicationsets/istio-base.yaml
@@ -40,8 +40,6 @@ spec:
             topology.istio.io/network: {{`'{{name}}'`}}
 {{- else if eq .Values.networkMode "single" }}
             topology.istio.io/network: {{`'{{metadata.labels.cell}}'`}}
-{{- else }}
-{{- fail (printf "unsupported networkMode %q (expected: multi|single)" .Values.networkMode) }}
 {{- end }}
       ignoreDifferences:
       - group: admissionregistration.k8s.io

--- a/charts/istio/templates/applicationsets/istio-base.yaml
+++ b/charts/istio/templates/applicationsets/istio-base.yaml
@@ -36,7 +36,13 @@ spec:
         - CreateNamespace=true
         managedNamespaceMetadata:
           labels:
+{{- if eq .Values.networkMode "multi" }}
             topology.istio.io/network: {{`'{{name}}'`}}
+{{- else if eq .Values.networkMode "single" }}
+            topology.istio.io/network: {{`'{{metadata.labels.cell}}'`}}
+{{- else }}
+{{- fail (printf "unsupported networkMode %q (expected: multi|single)" .Values.networkMode) }}
+{{- end }}
       ignoreDifferences:
       - group: admissionregistration.k8s.io
         kind: ValidatingWebhookConfiguration

--- a/charts/istio/templates/applicationsets/istio-ewgw.yaml
+++ b/charts/istio/templates/applicationsets/istio-ewgw.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.networkMode "multi" -}}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
@@ -31,3 +32,4 @@ spec:
       syncPolicy:
         syncOptions:
         - CreateNamespace=true
+{{- end }}

--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -44,8 +44,6 @@ spec:
                 AMBIENT_ENABLE_MULTI_NETWORK: "true"
 {{- else if eq .Values.networkMode "single" }}
                 AMBIENT_ENABLE_MULTI_NETWORK: "false"
-{{- else }}
-{{- fail (printf "unsupported networkMode %q (expected: multi|single)" .Values.networkMode) }}
 {{- end }}
                 AMBIENT_ENABLE_BAGGAGE: "true"
             global:
@@ -55,7 +53,7 @@ spec:
               meshID: {{`'{{metadata.labels.cell}}'`}}
 {{- if eq .Values.networkMode "multi" }}
               network: {{`'{{name}}'`}}
-{{- else }}
+{{- else if eq .Values.networkMode "single" }}
               network: {{`'{{metadata.labels.cell}}'`}}
 {{- end }}
               logAsJson: true

--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -40,14 +40,24 @@ spec:
                 # are otherwise rejected with UnsupportedProtocol.
                 PILOT_ENABLE_ALPHA_GATEWAY_API: "true"
                 ISTIOD_CUSTOM_HOST: {{`'istiod.{{name}}'`}}
+{{- if eq .Values.networkMode "multi" }}
                 AMBIENT_ENABLE_MULTI_NETWORK: "true"
+{{- else if eq .Values.networkMode "single" }}
+                AMBIENT_ENABLE_MULTI_NETWORK: "false"
+{{- else }}
+{{- fail (printf "unsupported networkMode %q (expected: multi|single)" .Values.networkMode) }}
+{{- end }}
                 AMBIENT_ENABLE_BAGGAGE: "true"
             global:
             # hub: ghcr.io/h0tbird
             # tag: 1.28.3-patch.1-dev
               variant: "debug"
               meshID: {{`'{{metadata.labels.cell}}'`}}
+{{- if eq .Values.networkMode "multi" }}
               network: {{`'{{name}}'`}}
+{{- else }}
+              network: {{`'{{metadata.labels.cell}}'`}}
+{{- end }}
               logAsJson: true
               defaultPodDisruptionBudget:
                 enabled: false

--- a/charts/istio/values.yaml
+++ b/charts/istio/values.yaml
@@ -1,1 +1,7 @@
 ---
+# Network topology mode used by the istio ApplicationSets:
+#   multi  - one Istio network per cluster, east-west gateway deployed (PR #28).
+#   single - one Istio network per cell (clusters in the same cell share a
+#            network), east-west gateway omitted. Cells remain isolated.
+# Overridden at deploy time by `bin/meshlab --network-mode=...`.
+networkMode: multi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -30,14 +30,14 @@ readonly DIM='\e[2m'
 readonly RST='\e[0m'
 
 #------------------------------------------------------------------------------
-# List the first ${WLCNT} workload cells (or their clusters)
+# List the first ${CELL_COUNT} workload cells (or their clusters)
 #------------------------------------------------------------------------------
 
-# List the first ${WLCNT} workload cells
+# List the first ${CELL_COUNT} workload cells
 cells() {
   local count=0
   for cell in "${!CELLS[@]}"; do
-    ((++count > ${WLCNT:-1})) && break
+    ((++count > ${CELL_COUNT:-1})) && break
     echo -n "${cell} "
   done
 }
@@ -47,11 +47,11 @@ all_cells() {
   echo "mngr $(cells)"
 }
 
-# List the first ${WLCNT} workload clusters
+# List the first ${CELL_COUNT} workload clusters
 clusters() {
   local count=0
   for cell in "${!CELLS[@]}"; do
-    ((++count > ${WLCNT:-1})) && break
+    ((++count > ${CELL_COUNT:-1})) && break
     echo -n "${CELLS[${cell}]} "
   done
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -61,48 +61,6 @@ all_clusters() {
   echo "${MNGR} $(clusters)"
 }
 
-# Manager cluster + every workload cluster across every cell (ignores CELL_COUNT).
-# Used as a safety fallback for cleanup when no persisted state is available.
-every_cluster() {
-  local out="${MNGR}"
-  for cell in "${!CELLS[@]}"; do
-    out+=" ${CELLS[${cell}]}"
-  done
-  echo "${out}"
-}
-
-# Path to the persisted lab state (CELL_COUNT, NETWORK_MODE) written by
-# `meshlab create` and consumed by `meshlab delete` so cleanup tears down
-# exactly what was provisioned.
-export MESHLAB_STATE_FILE="./tmp/.meshlab-state"
-
-save_state() {
-  mkdir -p "$(dirname "${MESHLAB_STATE_FILE}")"
-  cat > "${MESHLAB_STATE_FILE}" <<EOF
-CELL_COUNT=${CELL_COUNT}
-NETWORK_MODE=${NETWORK_MODE}
-EOF
-}
-
-# Load persisted state if present. Returns 0 if loaded, 1 otherwise.
-load_state() {
-  [[ -f "${MESHLAB_STATE_FILE}" ]] || return 1
-  # shellcheck disable=SC1090
-  source "${MESHLAB_STATE_FILE}"
-  export CELL_COUNT NETWORK_MODE
-}
-
-# Clusters that `meshlab delete` should tear down. If `meshlab create` left a
-# state file behind, honor it (delete exactly what was provisioned). Otherwise
-# fall back to every known cluster as a safety net for stale environments.
-clusters_to_clean() {
-  if [[ -f "${MESHLAB_STATE_FILE}" ]]; then
-    all_clusters
-  else
-    every_cluster
-  fi
-}
-
 #------------------------------------------------------------------------------
 # Returns the CIDR for the given cluster
 #------------------------------------------------------------------------------

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -61,6 +61,15 @@ all_clusters() {
   echo "${MNGR} $(clusters)"
 }
 
+# Manager cluster + every workload cluster across every cell (ignores CELL_COUNT)
+every_cluster() {
+  local out="${MNGR}"
+  for cell in "${!CELLS[@]}"; do
+    out+=" ${CELLS[${cell}]}"
+  done
+  echo "${out}"
+}
+
 #------------------------------------------------------------------------------
 # Returns the CIDR for the given cluster
 #------------------------------------------------------------------------------

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -61,13 +61,46 @@ all_clusters() {
   echo "${MNGR} $(clusters)"
 }
 
-# Manager cluster + every workload cluster across every cell (ignores CELL_COUNT)
+# Manager cluster + every workload cluster across every cell (ignores CELL_COUNT).
+# Used as a safety fallback for cleanup when no persisted state is available.
 every_cluster() {
   local out="${MNGR}"
   for cell in "${!CELLS[@]}"; do
     out+=" ${CELLS[${cell}]}"
   done
   echo "${out}"
+}
+
+# Path to the persisted lab state (CELL_COUNT, NETWORK_MODE) written by
+# `meshlab create` and consumed by `meshlab delete` so cleanup tears down
+# exactly what was provisioned.
+export MESHLAB_STATE_FILE="./tmp/.meshlab-state"
+
+save_state() {
+  mkdir -p "$(dirname "${MESHLAB_STATE_FILE}")"
+  cat > "${MESHLAB_STATE_FILE}" <<EOF
+CELL_COUNT=${CELL_COUNT}
+NETWORK_MODE=${NETWORK_MODE}
+EOF
+}
+
+# Load persisted state if present. Returns 0 if loaded, 1 otherwise.
+load_state() {
+  [[ -f "${MESHLAB_STATE_FILE}" ]] || return 1
+  # shellcheck disable=SC1090
+  source "${MESHLAB_STATE_FILE}"
+  export CELL_COUNT NETWORK_MODE
+}
+
+# Clusters that `meshlab delete` should tear down. If `meshlab create` left a
+# state file behind, honor it (delete exactly what was provisioned). Otherwise
+# fall back to every known cluster as a safety net for stale environments.
+clusters_to_clean() {
+  if [[ -f "${MESHLAB_STATE_FILE}" ]]; then
+    all_clusters
+  else
+    every_cluster
+  fi
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #28. Adds a single CLI flag on `bin/meshlab` that picks the Istio network topology at deploy time, defaulting to `multi` so current behavior is unchanged.

## Modes

| Aspect | `--network-mode=multi` (default) | `--network-mode=single` |
|---|---|---|
| `topology.istio.io/network` namespace label | `{{name}}` (per-cluster) | `{{metadata.labels.cell}}` (per-cell) |
| `pilot.env.AMBIENT_ENABLE_MULTI_NETWORK` | `"true"` | `"false"` |
| `global.network` | `{{name}}` | `{{metadata.labels.cell}}` |
| `istio-ewgw` ApplicationSet | rendered | omitted |
| `meshID` / `trustDomain` | per-cell | per-cell (unchanged) |
| Cells | isolated networks & meshes | isolated networks & meshes |

In `single` mode, the two clusters of a cell share one Istio network so no east-west gateway is needed between them. Cells stay independent in both modes.

## Implementation

- `bin/meshlab`: pre-parses `--network-mode=<value>` (and `--network-mode <value>`) before the existing positional dispatch, validates against `multi|single`, and exports `NETWORK_MODE`. `install-applicationsets` passes it through as `--set networkMode=$NETWORK_MODE` on the `charts/istio` meta-chart.
- `charts/istio/values.yaml`: adds `networkMode: multi` default.
- `charts/istio/templates/applicationsets/istio-{base,istiod,ewgw}.yaml`: branch on `.Values.networkMode`. Invalid values raise `{{ fail }}`.

## Verification

- `bash -n bin/meshlab` clean.
- ` ./bin/meshlab list` works with no flag, with `--network-mode=single`, and with `--network-mode multi`; rejects bogus values.
- `helm template ./charts/istio --set chartVersion=1.29.2` is byte-identical between the chart default, `--set networkMode=multi`, and the rendering on `master` (zero behavior change without the flag).
- `--set networkMode=single` diff vs `multi` is exactly the four planned changes (namespace label, `AMBIENT_ENABLE_MULTI_NETWORK`, `global.network`, EWGW AppSet absent).
- `--set networkMode=bogus` fails with a clear chart error.

## Out of scope

- Cilium ClusterMesh topology, `istio-endpoint-discovery`, and `lib/common.sh` cell topology are unchanged.
- Mode is fixed at deploy time; switching modes is supported by re-running `meshlab` (ArgoCD will reconcile, but stale `istio-ewgw` Applications from a prior `multi` deploy would need manual cleanup when switching to `single`).
- No cross-cell federation.