### PR TITLE
fix(devcontainer): pin docker-in-docker to Docker CE 29 to fix dind startup

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.16.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd",
+      "integrity": "sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/sshd@sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee",
+      "integrity": "sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,10 @@
 
 	],
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"version": "29",
+			"moby": false
+		},
 		"ghcr.io/devcontainers/features/sshd:1": {
 			"version": "latest"
 		}


### PR DESCRIPTION
## Summary

The \`dind\` command (\`docker -H unix:///var/run/docker.sock\`) suddenly stopped working with:

\`\`\`
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
\`\`\`

even though no changes had been made to \`.devcontainer/\`. This PR pins the \`docker-in-docker\` feature to a known-good configuration and commits the lockfile so the issue cannot silently reappear.

## What happened

The dev container references the feature with a floating major-version tag:

\`\`\`jsonc
"ghcr.io/devcontainers/features/docker-in-docker:2": {}
\`\`\`

On a fresh devcontainer build, the tooling re-resolved \`:2\` to feature release **2.16.1**, which is the first release that installs **Moby Engine 29.x** by default. Moby's 29.x packaging ships **\`containerd 2.3.0\`**, which is missing the \`io.containerd.transfer.v1\` plugin and does not expose the \`grpc.health.v1.Health\` service.

The result inside the container:

\`\`\`
failed to start containerd: timeout waiting for containerd to start
"daemon is not responding" error="Unimplemented: unknown service grpc.health.v1.Health"
\`\`\`

\`dockerd\` starts, fails its health probe against its own embedded \`containerd\`, and exits — leaving an orphan \`/var/run/docker.sock\` and the misleading "is the docker daemon running?" error.

This is also why the brand-new \`devcontainer-lock.json\` file appeared at the same time: VS Code's Dev Containers tooling now writes a lockfile whenever it resolves features, capturing the digest that was just pulled.

## Fix

\`\`\`jsonc
"ghcr.io/devcontainers/features/docker-in-docker:2": {
    "version": "29",
    "moby": false
}
\`\`\`

Two changes:

- **\`version: "29"\`** — pin the Docker engine major so we don't drift again.
- **\`moby: false\`** — install **Docker CE** instead of **Moby**.

Plus: commit \`.devcontainer/devcontainer-lock.json\` so the feature image itself is also pinned by digest.

## Moby vs. Docker CE — what's the difference?

Both are built from the same upstream code (the Moby Project), but they're packaged and shipped by different parties with different version-coupling guarantees:

| | **Moby** | **Docker CE** |
|---|---|---|
| Packages | \`moby-engine\`, \`moby-cli\`, \`moby-containerd\`, \`moby-buildx\`, … | \`docker-ce\`, \`docker-ce-cli\`, \`containerd.io\`, \`docker-buildx-plugin\`, … |
| Maintained by | Debian/Ubuntu distro maintainers (community) | Docker, Inc. |
| Repo | Distro APT repos | \`download.docker.com\` |
| \`containerd\` coupling | Separately versioned \`moby-containerd\`; can drift ahead of what \`moby-engine\` was tested with | \`containerd.io\` is QA'd as a matched pair with \`docker-ce\` of the same release |
| Telemetry / Docker Hub login UX | None | Some Docker Inc. extras |
| Stability profile | "Latest available bits", looser coupling | Conservative, validated combinations |

In this incident, **Moby** pulled in \`containerd 2.3.0\` while \`dockerd 29\` still expected the older containerd gRPC surface — exactly the kind of mismatch the matched \`docker-ce\` + \`containerd.io\` packaging avoids. The \`moby: false\` switch points the install script at Docker's own apt repo and gets us the matched pair. Inside the container after the fix:

\`\`\`
Server: Docker Engine - Community
 Engine:     v29.4.3
 containerd: v2.2.3   ← the working line
\`\`\`

## How to recognize this if it ever recurs

- \`dind ps\` fails with "Cannot connect to the Docker daemon"
- \`ps -ef | grep dockerd\` shows nothing running
- \`tail /tmp/dockerd.log\` (the docker-in-docker feature's log) contains \`failed to start containerd: timeout waiting for containerd to start\`
- \`dockerd --debug\` shows \`Unimplemented: unknown service grpc.health.v1.Health\`

If so: bump/pin a different \`version\`, or temporarily flip \`moby\` between \`true\`/\`false\` to swap packaging streams.

## Verification

\`\`\`
$ dind version
Server: Docker Engine - Community
 Version:    29.4.3
 containerd: v2.2.3

$ dind ps
CONTAINER ID   IMAGE   COMMAND   ...   (empty list, no error)

$ dood ps
CONTAINER ID   IMAGE   ...   meshlab    (host Docker Desktop, still works)
\`\`\`

Both \`dind\` (in-container daemon) and \`dood\` (host Docker Desktop via the bind-mounted \`docker-host.sock\`) are functional.
