### PR TITLE
fix(devcontainer): remove built-in github.copilot-chat from extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -95,7 +95,6 @@
 			},
 			"extensions": [
 				"github.copilot",
-				"github.copilot-chat",
 				"github.vscode-pull-request-github",
 				"golang.go",
 				"ms-azuretools.vscode-docker",


### PR DESCRIPTION
VS Code now ships `github.copilot-chat` as a built-in extension. Listing it in `devcontainer.json` caused the extension install step to attempt a downgrade and fail:

```
Error while installing the extension github.copilot-chat Extension 'github.copilot-chat' is a built-in extension with version '0.47.0' and cannot be downgraded to version '0.45.1'.
```

Removing it from the explicit extensions list resolves the error; the extension remains available because it is built in.