### PR TITLE
Upgrade meshlab components

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,7 +60,7 @@ RUN echo 'dind() { docker -H unix:///var/run/docker.sock "$@" }' >> /etc/zsh/zsh
 RUN echo "source <(meshlab completion zsh)" >> /etc/zsh/zshrc
 
 # Install Go (https://go.dev/dl/)
-RUN VERSION="1.26.2" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="1.26.3" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL https://go.dev/dl/go${VERSION}.linux-${ARCH}.tar.gz | tar -xzC /usr/local && \
     echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/zsh/zshenv && \
     echo 'export PATH=$PATH:$HOME/go/bin' >> /etc/zsh/zshenv
@@ -71,13 +71,13 @@ RUN VERSION="v0.31.0" && ARCH=$(archmap 'arm64' 'amd64') && \
     chmod +x /usr/local/bin/kind && echo "source <(kind completion zsh)" >> /etc/zsh/zshrc
 
 # Install kubectl (https://cdn.dl.k8s.io/release/stable.txt)
-RUN VERSION="v1.36.0" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="v1.36.1" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /usr/local/bin/kubectl https://dl.k8s.io/release/${VERSION}/bin/linux/${ARCH}/kubectl && \
     chmod +x /usr/local/bin/kubectl && ln -s /usr/local/bin/kubectl /usr/local/bin/k && \
     echo "source <(kubectl completion zsh)" >> /etc/zsh/zshrc
 
 # Install helm (https://github.com/helm/helm/releases)
-RUN VERSION="v4.1.4" && \
+RUN VERSION="v4.2.0" && \
     $CURL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/${VERSION}/scripts/get-helm-4 && \
     chmod 700 /tmp/get_helm.sh && /tmp/get_helm.sh --version ${VERSION} && rm -f /tmp/get_helm.sh && \
     echo "source <(helm completion zsh)" >> /etc/zsh/zshrc
@@ -88,7 +88,7 @@ RUN VERSION="v4.53.2" && ARCH=$(archmap 'arm64' 'amd64') && \
     chmod +x /usr/local/bin/yq && echo "source <(yq completion zsh)" >> /etc/zsh/zshrc
 
 # Install argocd (https://github.com/argoproj/argo-cd/releases)
-RUN VERSION="v3.3.8" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="v3.4.2" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/${VERSION}/argocd-linux-${ARCH} && \
     chmod +x /usr/local/bin/argocd && echo "source <(argocd completion zsh)" >> /etc/zsh/zshrc
 
@@ -131,12 +131,12 @@ RUN VERSION="0.3.7" && ARCH=$(archmap 'arm64' 'amd64') && \
     tar -xzC /usr/local/bin swarmctl && echo "source <(swarmctl completion zsh)" >> /etc/zsh/zshrc
 
 # Install btop (https://github.com/aristocratos/btop/releases)
-RUN VERSION="1.4.6" && ARCH=$(archmap 'aarch64' 'x86_64') && \
+RUN VERSION="1.4.7" && ARCH=$(archmap 'aarch64' 'x86_64') && \
     $CURL https://github.com/aristocratos/btop/releases/download/v${VERSION}/btop-${ARCH}-unknown-linux-musl.tbz | \
     tar -xjC /usr/local/bin --strip-components 3 -f - ./btop/bin/btop
 
 # Install tilt (https://github.com/tilt-dev/tilt/releases)
-RUN VERSION="0.37.2" && ARCH=$(archmap 'arm64' 'x86_64') && \
+RUN VERSION="0.37.3" && ARCH=$(archmap 'arm64' 'x86_64') && \
     $CURL https://github.com/tilt-dev/tilt/releases/download/v${VERSION}/tilt.${VERSION}.linux.${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin tilt && echo "source <(tilt completion zsh)" >> /etc/zsh/zshrc
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -132,8 +132,8 @@ RUN VERSION="0.3.7" && ARCH=$(archmap 'arm64' 'amd64') && \
 
 # Install btop (https://github.com/aristocratos/btop/releases)
 RUN VERSION="1.4.7" && ARCH=$(archmap 'aarch64' 'x86_64') && \
-    $CURL https://github.com/aristocratos/btop/releases/download/v${VERSION}/btop-${ARCH}-unknown-linux-musl.tbz | \
-    tar -xjC /usr/local/bin --strip-components 3 -f - ./btop/bin/btop
+    $CURL https://github.com/aristocratos/btop/releases/download/v${VERSION}/btop-${ARCH}-unknown-linux-musl.tar.gz | \
+    tar -xzC /usr/local/bin --strip-components 3 -f - ./btop/bin/btop
 
 # Install tilt (https://github.com/tilt-dev/tilt/releases)
 RUN VERSION="0.37.3" && ARCH=$(archmap 'arm64' 'x86_64') && \

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -21,19 +21,19 @@ NET_START=$(net_bytes)
 #------------------------------------------------------------------------------
 
 readonly KINDCCM_VERSION='0.10.0'                      # https://github.com/kubernetes-sigs/cloud-provider-kind/releases
-readonly CILIUM_CHART_VERSION='1.19.3'                 # https://artifacthub.io/packages/helm/cilium/cilium
+readonly CILIUM_CHART_VERSION='1.19.4'                 # https://artifacthub.io/packages/helm/cilium/cilium
 readonly K8S_GATEWAY_CHART_VERSION='3.7.1'             # https://github.com/k8s-gateway/k8s_gateway/blob/master/charts/k8s-gateway/Chart.yaml
-readonly ARGOCD_CHART_VERSION='9.5.7'                  # https://artifacthub.io/packages/helm/argo-cd-oci/argo-cd
-readonly ARGOWF_CHART_VERSION='1.0.13'                 # https://artifacthub.io/packages/helm/argo/argo-workflows
-readonly PROMETHEUS_CHART_VERSION='29.3.0'             # https://artifacthub.io/packages/helm/prometheus-community/prometheus
+readonly ARGOCD_CHART_VERSION='9.5.14'                 # https://artifacthub.io/packages/helm/argo-cd-oci/argo-cd
+readonly ARGOWF_CHART_VERSION='1.0.14'                 # https://artifacthub.io/packages/helm/argo/argo-workflows
+readonly PROMETHEUS_CHART_VERSION='29.6.0'             # https://artifacthub.io/packages/helm/prometheus-community/prometheus
 readonly GRAFANA_CHART_VERSION='10.5.15'               # https://artifacthub.io/packages/helm/grafana/grafana
-readonly OTEL_COLLECTOR_CHART_VERSION='0.152.0'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
+readonly OTEL_COLLECTOR_CHART_VERSION='0.154.0'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
 readonly VAULT_CHART_VERSION='0.32.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
 readonly CERT_MANAGER_CHART_VERSION='v1.20.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
 readonly KUBERNETES_REPLICATOR_CHART_VERSION='2.12.3'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
 readonly METRICS_SERVER_CHART_VERSION='3.13.0'         # https://artifacthub.io/packages/helm/metrics-server/metrics-server
 readonly ISTIO_CHART_VERSION='1.29.2'                  # https://artifacthub.io/packages/helm/istio-official/base
-readonly KIALI_CHART_VERSION='2.25.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
+readonly KIALI_CHART_VERSION='2.26.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
 
 #------------------------------------------------------------------------------
 # [i] Cleanup


### PR DESCRIPTION
## Helm Charts (bin/meshlab)
| Component | Previous | Latest |
|-----------|----------|--------|
| Cilium | 1.19.3 | 1.19.4 |
| Argo CD | 9.5.7 | 9.5.14 |
| Argo Workflows | 1.0.13 | 1.0.14 |
| Prometheus | 29.3.0 | 29.6.0 |
| OpenTelemetry Collector | 0.152.0 | 0.154.0 |
| Kiali Operator | 2.25.0 | 2.26.0 |

## CLI Tools (.devcontainer/Dockerfile)
| Tool | Previous | Latest |
|------|----------|--------|
| Go | 1.26.2 | 1.26.3 |
| kubectl | v1.36.0 | v1.36.1 |
| helm | v4.1.4 | v4.2.0 |
| argocd | v3.3.8 | v3.4.2 |
| btop | 1.4.6 | 1.4.7 |
| tilt | 0.37.2 | 0.37.3 |