### PR TITLE
Upgrade meshlab components

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -103,7 +103,7 @@ RUN VERSION="v0.19.2" && ARCH=$(archmap 'arm64' 'amd64') && \
     chmod +x /usr/local/bin/cilium && echo "source <(cilium completion zsh)" >> /etc/zsh/zshrc
 
 # Install istioctl (https://github.com/istio/istio/releases)
-RUN VERSION="1.29.2" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="1.30.0" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /tmp/istio.tar.gz https://github.com/istio/istio/releases/download/${VERSION}/istio-${VERSION}-linux-${ARCH}.tar.gz && \
     tar -xC /usr/local/bin --strip-components 2 -f /tmp/istio.tar.gz istio-${VERSION}/bin/istioctl && rm -f /tmp/istio.tar.gz && \
     echo "source <(istioctl completion zsh)" >> /etc/zsh/zshrc
@@ -141,7 +141,7 @@ RUN VERSION="0.37.3" && ARCH=$(archmap 'arm64' 'x86_64') && \
     tar -xzC /usr/local/bin tilt && echo "source <(tilt completion zsh)" >> /etc/zsh/zshrc
 
 # Install crane (https://github.com/google/go-containerregistry/releases)
-RUN VERSION="v0.21.5" && ARCH=$(archmap 'arm64' 'x86_64') && \
+RUN VERSION="v0.21.6" && ARCH=$(archmap 'arm64' 'x86_64') && \
     $CURL https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin crane && echo "source <(crane completion zsh)" >> /etc/zsh/zshrc
 

--- a/.github/skills/upgrade-components/SKILL.md
+++ b/.github/skills/upgrade-components/SKILL.md
@@ -146,6 +146,39 @@ version_dot  = '1.30.0'   # dotted form, must match ISTIO_CHART_VERSION
 Both must stay in lockstep with the Istio chart version. No other Tiltfile
 edits are required.
 
+## Istio Image & Binary Rebuild (required on every Istio bump)
+
+When `ISTIO_CHART_VERSION` is bumped, the Istio fork in `/workspaces/istio`
+must be synced and the images + binaries rebuilt so that the Tiltfile
+live-reload loop can consume them.
+
+1. **Sync the fork with upstream and check out the target tag**:
+
+   ```bash
+   cd /workspaces/istio
+   git fetch upstream --tags
+   git checkout <ISTIO_CHART_VERSION>   # e.g. 1.30.0
+   ```
+
+   The `1.x.y` release tags live on `upstream` (`istio/istio`), not on the
+   `h0tbird/forked-istio` `origin`, so `git fetch --tags` alone (which only
+   pulls from `origin`) is not enough — always fetch from `upstream`
+   explicitly.
+
+2. **Publish new multi-arch images to ghcr.io** so the Tiltfile can pull them
+   (run from `/workspaces/meshlab`, where the `Makefile` lives):
+
+   ```bash
+   make istio-images ISTIO_HUB=ghcr.io/h0tbird ISTIO_TAG=<ISTIO_CHART_VERSION>
+   ```
+
+3. **Rebuild the Istio binaries** so the Tiltfile live-reload loop redeploys
+   `pilot-discovery` with the new code (also from `/workspaces/meshlab`):
+
+   ```bash
+   make istio-binaries
+   ```
+
 ## Important Considerations
 
 - **Prefer stable releases** over pre-release/alpha/beta/RC versions for all components

--- a/.github/skills/upgrade-components/SKILL.md
+++ b/.github/skills/upgrade-components/SKILL.md
@@ -135,7 +135,7 @@ RUN VERSION="v0.32.0" && ARCH=$(archmap 'arm64' 'amd64') && \
 ```
 
 ### For `Tiltfile` (Istio only):
-When `ISTIO_CHART_VERSION` is bumped, also update the two version variables
+When `ISTIO_CHART_VERSION` is bumped, update the two version variables
 near the top of `Tiltfile`:
 
 ```starlark
@@ -143,8 +143,26 @@ version_dash = '1-30-0'   # dashed form, used in revision labels
 version_dot  = '1.30.0'   # dotted form, must match ISTIO_CHART_VERSION
 ```
 
-Both must stay in lockstep with the Istio chart version. No other Tiltfile
-edits are required.
+Both must stay in lockstep with the Istio chart version.
+
+In addition, the `Tiltfile` embeds a full `kind: Deployment` manifest for
+`istiod` that mirrors the Deployment rendered by the upstream Istio Helm
+chart. New Istio versions frequently tweak this Deployment (new env vars,
+changed args, new volume mounts, updated probes, etc.), so the embedded
+manifest **may also need to be updated** to stay in sync.
+
+The diff cannot be computed reliably from the chart alone — the user
+verifies it through **ArgoCD** (which renders the chart in-cluster and
+shows the diff between what ArgoCD wants to apply and what Tilt has
+mutated). After the new chart is deployed:
+
+1. Open the istiod Application in ArgoCD and inspect the diff for the
+   `istiod-<version_dash>` Deployment.
+2. Port any non-Tilt-specific changes (new env vars, args, volumes, etc.)
+   into the embedded YAML in `Tiltfile`. Do **not** touch the bits Tilt
+   injects (the `image:` reference, restart annotations, sync mounts).
+3. Ask the user before making these edits if the diff is ambiguous —
+   never guess at chart changes without seeing the ArgoCD diff.
 
 ## Istio Image & Binary Rebuild (required on every Istio bump)
 

--- a/.github/skills/upgrade-components/SKILL.md
+++ b/.github/skills/upgrade-components/SKILL.md
@@ -5,9 +5,10 @@ description: Upgrades meshlab component versions defined in bin/meshlab (Helm ch
 
 # Meshlab Component Upgrade Skill
 
-This skill helps upgrade the versions of all meshlab infrastructure components defined in two locations:
+This skill helps upgrade the versions of all meshlab infrastructure components defined in these locations:
 - `bin/meshlab` - Helm chart versions for deployed components
 - `.devcontainer/Dockerfile` - CLI tool versions for the development environment
+- `Tiltfile` - Istio version pinned for the `pilot-discovery` live-reload dev loop (must be bumped in lockstep with `ISTIO_CHART_VERSION`)
 
 ---
 
@@ -132,6 +133,18 @@ Example:
 ```dockerfile
 RUN VERSION="v0.32.0" && ARCH=$(archmap 'arm64' 'amd64') && \
 ```
+
+### For `Tiltfile` (Istio only):
+When `ISTIO_CHART_VERSION` is bumped, also update the two version variables
+near the top of `Tiltfile`:
+
+```starlark
+version_dash = '1-30-0'   # dashed form, used in revision labels
+version_dot  = '1.30.0'   # dotted form, must match ISTIO_CHART_VERSION
+```
+
+Both must stay in lockstep with the Istio chart version. No other Tiltfile
+edits are required.
 
 ## Important Considerations
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -15,8 +15,8 @@ allow_k8s_contexts([
 # Variables
 #------------------------------------------------------------------------------
 
-version_dash = '1-29-2'
-version_dot = '1.29.2'
+version_dash = '1-30-0'
+version_dot = '1.30.0'
 image_ref = 'pilot-discovery-dev'
 cluster_name = k8s_context().removeprefix('kind-')
 

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -25,14 +25,14 @@ readonly CILIUM_CHART_VERSION='1.19.4'                 # https://artifacthub.io/
 readonly K8S_GATEWAY_CHART_VERSION='3.7.1'             # https://github.com/k8s-gateway/k8s_gateway/blob/master/charts/k8s-gateway/Chart.yaml
 readonly ARGOCD_CHART_VERSION='9.5.14'                 # https://artifacthub.io/packages/helm/argo-cd-oci/argo-cd
 readonly ARGOWF_CHART_VERSION='1.0.14'                 # https://artifacthub.io/packages/helm/argo/argo-workflows
-readonly PROMETHEUS_CHART_VERSION='29.6.0'             # https://artifacthub.io/packages/helm/prometheus-community/prometheus
+readonly PROMETHEUS_CHART_VERSION='29.7.0'             # https://artifacthub.io/packages/helm/prometheus-community/prometheus
 readonly GRAFANA_CHART_VERSION='10.5.15'               # https://artifacthub.io/packages/helm/grafana/grafana
-readonly OTEL_COLLECTOR_CHART_VERSION='0.154.0'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
+readonly OTEL_COLLECTOR_CHART_VERSION='0.156.0'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
 readonly VAULT_CHART_VERSION='0.32.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
 readonly CERT_MANAGER_CHART_VERSION='v1.20.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
 readonly KUBERNETES_REPLICATOR_CHART_VERSION='2.12.3'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
 readonly METRICS_SERVER_CHART_VERSION='3.13.0'         # https://artifacthub.io/packages/helm/metrics-server/metrics-server
-readonly ISTIO_CHART_VERSION='1.29.2'                  # https://artifacthub.io/packages/helm/istio-official/base
+readonly ISTIO_CHART_VERSION='1.30.0'                  # https://artifacthub.io/packages/helm/istio-official/base
 readonly KIALI_CHART_VERSION='2.26.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Helm Charts (bin/meshlab)
| Component | Previous | Latest |
|---|---|---|
| Prometheus | 29.6.0 | 29.7.0 |
| OTel Collector | 0.154.0 | 0.156.0 |
| Istio base | 1.29.2 | 1.30.0 |

## CLI Tools (.devcontainer/Dockerfile)
| Tool | Previous | Latest |
|---|---|---|
| istioctl | 1.29.2 | 1.30.0 |
| crane | v0.21.5 | v0.21.6 |

## Tiltfile
- Istio version bumped 1.29.2 -> 1.30.0 to track ISTIO_CHART_VERSION.

## Skill update
- upgrade-components skill now documents the Tiltfile lockstep requirement.

Notes:
- cert-manager skipped: latest is v1.21.0-alpha.0; staying on stable v1.20.2.
- Istio bumped across a minor (1.29 -> 1.30). Review release notes before deploy.