### PR TITLE
Drop failurePolicy ignoreDifferences workaround

### DIFF
--- a/charts/istio/templates/applicationsets/istio-base.yaml
+++ b/charts/istio/templates/applicationsets/istio-base.yaml
@@ -41,8 +41,3 @@ spec:
 {{- else if eq .Values.networkMode "single" }}
             topology.istio.io/network: {{`'{{metadata.labels.cell}}'`}}
 {{- end }}
-      ignoreDifferences:
-      - group: admissionregistration.k8s.io
-        kind: ValidatingWebhookConfiguration
-        jsonPointers:
-        - /webhooks/0/failurePolicy

--- a/charts/istio/templates/applicationsets/istio-istiod.yaml
+++ b/charts/istio/templates/applicationsets/istio-istiod.yaml
@@ -101,8 +101,3 @@ spec:
       destination:
         server: {{`'{{server}}'`}}
         namespace: istio-system
-      ignoreDifferences:
-      - group: admissionregistration.k8s.io
-        kind: ValidatingWebhookConfiguration
-        jsonPointers:
-        - /webhooks/0/failurePolicy


### PR DESCRIPTION
## Context

Argo CD applies manifests via server-side apply. Pre-1.30, the Istio Helm chart rendered `webhooks[0].failurePolicy` on the `ValidatingWebhookConfiguration`, which conflicted with the value the istiod webhook controller sets at runtime. Argo CD would then perpetually show the istio-base / istio-istiod Applications as `OutOfSync` on that field, so we masked it with:

```yaml
ignoreDifferences:
- group: admissionregistration.k8s.io
  kind: ValidatingWebhookConfiguration
  jsonPointers:
  - /webhooks/0/failurePolicy
```

## Change

Istio 1.30 fixed this upstream (istio/istio#58302, istio/istio#59367): the chart now omits `failurePolicy` from the webhook template on upgrade, leaving the field owned exclusively by the webhook controller. Since meshlab already runs chart 1.30.0, the workaround is no longer needed.

This PR removes the `ignoreDifferences` block from both:
- `charts/istio/templates/applicationsets/istio-base.yaml`
- `charts/istio/templates/applicationsets/istio-istiod.yaml`

## Test plan

1. `meshlab up` from a clean state.
2. Verify both `*-istio-base` and `*-istio-istiod` Applications reach `Synced` / `Healthy` in Argo CD.
3. `meshlab restart-istiod` (or any upgrade-style reconcile) and confirm neither Application drifts to `OutOfSync` on `webhooks[0].failurePolicy`.
4. `kubectl get validatingwebhookconfiguration istio-validator-<rev>-istio-system -o jsonpath='{.webhooks[0].failurePolicy}'` still returns the controller-managed value (`Fail` by default).