### PR TITLE
Upgrade meshlab components

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,13 +60,13 @@ RUN echo 'dind() { docker -H unix:///var/run/docker.sock "$@" }' >> /etc/zsh/zsh
 RUN echo "source <(meshlab completion zsh)" >> /etc/zsh/zshrc
 
 # Install Go (https://go.dev/dl/)
-RUN VERSION="1.26.3" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="1.26.4" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL https://go.dev/dl/go${VERSION}.linux-${ARCH}.tar.gz | tar -xzC /usr/local && \
     echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/zsh/zshenv && \
     echo 'export PATH=$PATH:$HOME/go/bin' >> /etc/zsh/zshenv
 
 # Install kind (https://github.com/kubernetes-sigs/kind/releases)
-RUN VERSION="v0.31.0" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="v0.32.0" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/${VERSION}/kind-linux-${ARCH} && \
     chmod +x /usr/local/bin/kind && echo "source <(kind completion zsh)" >> /etc/zsh/zshrc
 
@@ -83,7 +83,7 @@ RUN VERSION="v4.2.0" && \
     echo "source <(helm completion zsh)" >> /etc/zsh/zshrc
 
 # Install yq (https://github.com/mikefarah/yq/releases)
-RUN VERSION="v4.53.2" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="v4.53.3" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${VERSION}/yq_linux_${ARCH} && \
     chmod +x /usr/local/bin/yq && echo "source <(yq completion zsh)" >> /etc/zsh/zshrc
 
@@ -103,7 +103,7 @@ RUN VERSION="v0.19.4" && ARCH=$(archmap 'arm64' 'amd64') && \
     chmod +x /usr/local/bin/cilium && echo "source <(cilium completion zsh)" >> /etc/zsh/zshrc
 
 # Install istioctl (https://github.com/istio/istio/releases)
-RUN VERSION="1.30.0" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="1.30.1" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /tmp/istio.tar.gz https://github.com/istio/istio/releases/download/${VERSION}/istio-${VERSION}-linux-${ARCH}.tar.gz && \
     tar -xC /usr/local/bin --strip-components 2 -f /tmp/istio.tar.gz istio-${VERSION}/bin/istioctl && rm -f /tmp/istio.tar.gz && \
     echo "source <(istioctl completion zsh)" >> /etc/zsh/zshrc

--- a/Tiltfile
+++ b/Tiltfile
@@ -15,8 +15,8 @@ allow_k8s_contexts([
 # Variables
 #------------------------------------------------------------------------------
 
-version_dash = '1-30-0'
-version_dot = '1.30.0'
+version_dash = '1-30-1'
+version_dot = '1.30.1'
 image_ref = 'pilot-discovery-dev'
 cluster_name = k8s_context().removeprefix('kind-')
 

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -23,17 +23,17 @@ NET_START=$(net_bytes)
 readonly KINDCCM_VERSION='0.10.0'                      # https://github.com/kubernetes-sigs/cloud-provider-kind/releases
 readonly CILIUM_CHART_VERSION='1.19.4'                 # https://artifacthub.io/packages/helm/cilium/cilium
 readonly K8S_GATEWAY_CHART_VERSION='3.7.1'             # https://github.com/k8s-gateway/k8s_gateway/blob/master/charts/k8s-gateway/Chart.yaml
-readonly ARGOCD_CHART_VERSION='9.5.17'                 # https://artifacthub.io/packages/helm/argo-cd-oci/argo-cd
+readonly ARGOCD_CHART_VERSION='9.5.20'                 # https://artifacthub.io/packages/helm/argo-cd-oci/argo-cd
 readonly ARGOWF_CHART_VERSION='1.0.14'                 # https://artifacthub.io/packages/helm/argo/argo-workflows
-readonly PROMETHEUS_CHART_VERSION='29.9.0'             # https://artifacthub.io/packages/helm/prometheus-community/prometheus
+readonly PROMETHEUS_CHART_VERSION='29.10.1'            # https://artifacthub.io/packages/helm/prometheus-community/prometheus
 readonly GRAFANA_CHART_VERSION='10.5.15'               # https://artifacthub.io/packages/helm/grafana/grafana
-readonly OTEL_COLLECTOR_CHART_VERSION='0.158.0'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
-readonly VAULT_CHART_VERSION='0.32.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
+readonly OTEL_COLLECTOR_CHART_VERSION='0.158.1'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
+readonly VAULT_CHART_VERSION='0.33.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
 readonly CERT_MANAGER_CHART_VERSION='v1.20.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
 readonly KUBERNETES_REPLICATOR_CHART_VERSION='2.12.3'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
 readonly METRICS_SERVER_CHART_VERSION='3.13.0'         # https://artifacthub.io/packages/helm/metrics-server/metrics-server
-readonly ISTIO_CHART_VERSION='1.30.0'                  # https://artifacthub.io/packages/helm/istio-official/base
-readonly KIALI_CHART_VERSION='2.26.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
+readonly ISTIO_CHART_VERSION='1.30.1'                  # https://artifacthub.io/packages/helm/istio-official/base
+readonly KIALI_CHART_VERSION='2.27.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
 
 #------------------------------------------------------------------------------
 # [i] Cleanup


### PR DESCRIPTION
## Helm Charts (bin/meshlab)
| Component | Previous | Latest | Status |
|-----------|----------|--------|--------|
| Argo CD | 9.5.17 | 9.5.20 | ✅ Upgraded |
| Prometheus | 29.9.0 | 29.10.1 | ✅ Upgraded |
| OpenTelemetry Collector | 0.158.0 | 0.158.1 | ✅ Upgraded |
| Vault | 0.32.0 | 0.33.0 | ✅ Upgraded |
| Istio | 1.30.0 | 1.30.1 | ✅ Upgraded |
| Kiali Operator | 2.26.0 | 2.27.0 | ✅ Upgraded |

## CLI Tools (.devcontainer/Dockerfile)
| Tool | Previous | Latest | Status |
|------|----------|--------|--------|
| Go | 1.26.3 | 1.26.4 | ✅ Upgraded |
| kind | v0.31.0 | v0.32.0 | ✅ Upgraded |
| yq | v4.53.2 | v4.53.3 | ✅ Upgraded |
| istioctl | 1.30.0 | 1.30.1 | ✅ Upgraded |

## Tiltfile
- Istio `version_dash` / `version_dot`: 1.30.0 -> 1.30.1

### Follow-up (Istio bump)
The Istio 1.30.0 -> 1.30.1 chart bump still requires syncing the istio fork to tag `1.30.1`, rebuilding images (`make istio-images`) and binaries (`make istio-binaries`), and verifying the embedded istiod Deployment in the Tiltfile against the ArgoCD diff.