### PR TITLE
Replace multiple registry:2 pull-through caches with a single zot instance

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,15 +23,17 @@ ENV CURL="curl -fsSL --retry 8 --retry-all-errors --retry-max-time 120 --connect
 
 # Architecture helper: archmap <arm64_value> <amd64_value>
 # Exits non-zero on unsupported architectures so broken downloads fail loudly.
-RUN printf '#!/bin/sh\ncase "$(arch)" in aarch64) echo "$1";; x86_64) echo "$2";; *) echo "archmap: unsupported arch $(arch)" >&2; exit 1;; esac\n' > /usr/local/bin/archmap && \
-    chmod +x /usr/local/bin/archmap
+RUN cat > /usr/local/bin/archmap <<'EOF' && chmod +x /usr/local/bin/archmap
+#!/bin/sh
+case "$(arch)" in
+    aarch64) echo "$1" ;;
+    x86_64)  echo "$2" ;;
+    *) echo "archmap: unsupported arch $(arch)" >&2; exit 1 ;;
+esac
+EOF
 
 # Install base packages.
-# Configure apt to retry transient failures and time out on slow mirrors, so
-# flaky DNS in BuildKit's netns (e.g. ports.ubuntu.com on arm64) doesn't break
-# the build.
-RUN printf 'Acquire::Retries "8";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-retries && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     curl jq iputils-ping dnsutils neovim socat \
     netcat-openbsd apache2-utils shellcheck \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,7 +49,7 @@
 		"--network", "host",
 		"--privileged"
 	],
-	"forwardPorts": [8080, 8081, 8082, 8083, 8084, 8085, 9091, 9092],
+	"forwardPorts": [8080, 8081, 8082, 8083, 8084, 8085, 8086, 9091, 9092],
 	"portsAttributes": {
 		"8080": {
 			"label": "argocd",
@@ -78,6 +78,11 @@
 		},
 		"8085": {
 			"label": "kiali",
+			"onAutoForward": "notify",
+			"protocol": "http"
+		},
+		"8086": {
+			"label": "zot",
 			"onAutoForward": "notify",
 			"protocol": "http"
 		},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,7 +49,7 @@
 		"--network", "host",
 		"--privileged"
 	],
-	"forwardPorts": [8080, 8081, 8082, 8083, 8084, 8085, 8086, 9091, 9092],
+	"forwardPorts": [8080, 8081, 8082, 8083, 8084, 8085, 9091, 9092],
 	"portsAttributes": {
 		"8080": {
 			"label": "argocd",
@@ -78,11 +78,6 @@
 		},
 		"8085": {
 			"label": "kiali",
-			"onAutoForward": "notify",
-			"protocol": "http"
-		},
-		"8086": {
-			"label": "zot",
 			"onAutoForward": "notify",
 			"protocol": "http"
 		},

--- a/.github/skills/open-webui/SKILL.md
+++ b/.github/skills/open-webui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-webui
-description: Opens meshlab web UIs (ArgoCD, Argo Workflows, Vault, Prometheus, Grafana, Kiali, Tilt) in the integrated browser. Use this skill when asked to open, access, check, or view any of the lab's web dashboards or UIs.
+description: Opens meshlab web UIs (ArgoCD, Argo Workflows, Vault, Prometheus, Grafana, Kiali, Zot, Tilt) in the integrated browser. Use this skill when asked to open, access, check, or view any of the lab's web dashboards or UIs.
 ---
 
 # Open Web UI Skill
@@ -21,6 +21,7 @@ The VS Code setting `workbench.browser.enableChatTools` must be `true`.
 | Prometheus | http://127.0.0.1:8083 | - |
 | Grafana | http://127.0.0.1:8084 | admin / meshlab123 |
 | Kiali | http://127.0.0.1:8085 | - |
+| Zot | http://127.0.0.1:8086 | - |
 | Tilt pasta-1 | http://127.0.0.1:9091 | - |
 | Tilt pasta-2 | http://127.0.0.1:9092 | - |
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tmp/
+.zot/
 docs/book/book/
 *.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-tmp/
-.zot/
+.tmp/
 docs/book/book/
 *.gz

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -99,42 +99,30 @@ cloud-provider-kind() {
 pull-through-cache() {
   blue "───[ Pull-through cache (zot) ]─────────────────────────────────────────"
 
-  # Already running? Nothing to do (its blob store persists across restarts).
-  if docker ps --format '{{.Names}}' | grep -qx "${ZOT_HOST}"; then
-    echo "zot already running, skipping install"
-    return 0
-  fi
-
-  # Remove any stale (stopped) zot container; the named volume below keeps the
-  # cached blobs, so recreating the container is cheap and picks up config edits.
-  docker rm -f "${ZOT_HOST}" >/dev/null 2>&1 || true
-
-  # Render config.json from the REGISTRIES map. Each upstream becomes an
-  # on-demand `sync` registry whose cached images live under its own destination
-  # prefix (the upstream host). `compat`/`preserveDigest` keep Docker media types
-  # intact so `image@sha256:` pulls still resolve. `search` + `ui` enable the
-  # bundled web interface (same binary, no extra component).
+  # Render config.json from the REGISTRIES map (fed as tab-separated
+  # upstream<TAB>url lines). Each upstream becomes an on-demand `sync` registry
+  # whose cached images live under its own destination prefix. `compat`/
+  # `preserveDigest` keep Docker media types intact so `image@sha256:` pulls
+  # still resolve. `search` + `ui` enable the bundled web interface.
   mkdir -p "${ZOT_DIR}"
-  local upstream registries_json
-  registries_json=$(
-    for upstream in "${!REGISTRIES[@]}"; do
-      jq -n --arg url "${REGISTRIES[${upstream}]}" --arg dest "/${upstream}" '{
-        urls: [$url],
-        onDemand: true,
-        tlsVerify: true,
-        preserveDigest: true,
-        content: [{ prefix: "**", destination: $dest }]
-      }'
-    done | jq -s '.'
-  )
-
-  jq -n --argjson regs "${registries_json}" '{
+  local upstream
+  for upstream in "${!REGISTRIES[@]}"; do
+    printf '%s\t%s\n' "${upstream}" "${REGISTRIES[${upstream}]}"
+  done | jq -R -s '{
     distSpecVersion: "1.1.0",
     storage: { rootDirectory: "/var/lib/registry", gc: true, dedupe: true },
     http: { address: "0.0.0.0", port: "8080", compat: ["docker2s2"] },
     log: { level: "info" },
     extensions: {
-      sync: { enable: true, registries: $regs },
+      sync: { enable: true, registries: (
+        split("\n") | map(select(length > 0) | split("\t") | {
+          urls: [.[1]],
+          onDemand: true,
+          tlsVerify: true,
+          preserveDigest: true,
+          content: [{ prefix: "**", destination: "/" + .[0] }]
+        })
+      ) },
       search: { enable: true },
       ui: { enable: true }
     }
@@ -150,16 +138,15 @@ pull-through-cache() {
   # bind-mounted read-only from its host path (${ZOT_DIR_HOST}); under DooD the
   # mount source resolves on the host filesystem, and the workspace is
   # bind-mounted there, so the in-container ${ZOT_DIR} maps to ${ZOT_DIR_HOST}.
-  docker run -d \
+  # Skip if already running (its blob store persists across restarts).
+  docker ps --format '{{.Names}}' | grep -qx "${ZOT_HOST}" || \
+  docker run --rm -d \
     --name "${ZOT_HOST}" \
     --network kind \
-    --restart always \
     -p "127.0.0.1:${ZOT_UI_PORT}:8080" \
     -v "${ZOT_DIR_HOST}/config.json:/etc/zot/config.json:ro" \
     -v "${ZOT_VOLUME}:/var/lib/registry" \
     "ghcr.io/project-zot/zot:v${ZOT_VERSION}" >/dev/null
-
-  echo "zot UI: http://127.0.0.1:${ZOT_UI_PORT}"
 }; SECTIONS+=( pull-through-cache )
 
 #------------------------------------------------------------------------------

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -96,11 +96,10 @@ cloud-provider-kind() {
 pull-through-cache() {
   blue "───[ Pull-through cache (zot) ]─────────────────────────────────────────"
 
-  # Render config.json from the REGISTRIES map (fed as tab-separated
-  # upstream<TAB>url lines). Each upstream becomes an on-demand `sync` registry
-  # whose cached images live under its own destination prefix. `compat`/
-  # `preserveDigest` keep Docker media types intact so `image@sha256:` pulls
-  # still resolve. `search` + `ui` enable the bundled web interface.
+  # Render config.json from the REGISTRIES map (tab-separated upstream<TAB>url).
+  # Each upstream becomes an on-demand `sync` registry cached under its own
+  # prefix. `compat`/`preserveDigest` keep Docker media types intact for
+  # `image@sha256:` pulls; `search`/`ui` enable the bundled web interface.
   mkdir -p "${ZOT_DIR}"
   local upstream
   for upstream in "${!REGISTRIES[@]}"; do
@@ -195,11 +194,9 @@ create-clusters() {
 add-registries-to-containerd() {
   blue "───[ Configure containerd ]─────────────────────────────────────────────"
 
-  # Route each upstream through its zot destination prefix. `override_path` makes
-  # containerd treat that path as the registry API root, so a pull of e.g.
-  # docker.io/library/nginx becomes a request to
-  # http://${ZOT_HOST}:${ZOT_PORT}/v2/docker.io/library/nginx. The `server` line
-  # keeps the real upstream as a fallback if zot is unreachable.
+  # Route each upstream through its zot prefix. `override_path` treats that path
+  # as the registry API root (docker.io/library/nginx -> http://${ZOT_HOST}:
+  # ${ZOT_PORT}/v2/docker.io/library/nginx); `server` is the upstream fallback.
   for cluster in $(all_clusters); do (
     local upstream url
     for upstream in "${!REGISTRIES[@]}"; do

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -11,7 +11,6 @@ set -euo pipefail
 cd "$(dirname "$0")"/..
 
 # Ensure the temporary directory exists
-HOST_TMP="${LOCAL_WORKSPACE_FOLDER}/.tmp"
 mkdir -p .tmp
 
 # shellcheck source=../lib/common.sh

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -47,6 +47,7 @@ readonly ZOT_VERSION='2.1.17'                          # https://github.com/proj
 cleanup() {
   blue "───[ Cleanup ]──────────────────────────────────────────────────────────"
 
+  # Delete the ArgoCD context (if it exists)
   argocd context --delete "${MNGR}" 2>/dev/null || true
 
   # Only kill tilt instances we started (one per workload cluster)

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -141,23 +141,23 @@ pull-through-cache() {
   }' > "${ZOT_DIR}/config.json"
 
   # Persistent blob store. docker here is DooD (the CLI talks to the host
-  # daemon), so the devcontainer filesystem can't be bind-mounted; use a named
-  # volume instead. It survives `docker rm`, so the cache persists across
-  # `meshlab delete`.
+  # daemon), so use a named volume instead of a devcontainer-local path. It
+  # survives `docker rm`, so the cache persists across `meshlab delete`.
   docker volume create "${ZOT_VOLUME}" >/dev/null
 
-  # Create the container on the kind network (so nodes resolve it as ${ZOT_HOST})
-  # with the UI/API published on the host at ${ZOT_UI_PORT}, inject the rendered
-  # config (can't bind-mount under DooD), then start it.
-  docker create \
+  # Run zot on the kind network (so nodes resolve it as ${ZOT_HOST}) with the
+  # UI/API published on the host at ${ZOT_UI_PORT}. The rendered config is
+  # bind-mounted read-only from its host path (${ZOT_DIR_HOST}); under DooD the
+  # mount source resolves on the host filesystem, and the workspace is
+  # bind-mounted there, so the in-container ${ZOT_DIR} maps to ${ZOT_DIR_HOST}.
+  docker run -d \
     --name "${ZOT_HOST}" \
     --network kind \
     --restart always \
     -p "127.0.0.1:${ZOT_UI_PORT}:8080" \
+    -v "${ZOT_DIR_HOST}/config.json:/etc/zot/config.json:ro" \
     -v "${ZOT_VOLUME}:/var/lib/registry" \
     "ghcr.io/project-zot/zot:v${ZOT_VERSION}" >/dev/null
-  docker cp "${ZOT_DIR}/config.json" "${ZOT_HOST}:/etc/zot/config.json"
-  docker start "${ZOT_HOST}" >/dev/null
 
   echo "zot UI: http://127.0.0.1:${ZOT_UI_PORT}"
 }; SECTIONS+=( pull-through-cache )

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -105,9 +105,6 @@ pull-through-cache() {
     return 0
   fi
 
-  # Drop any legacy per-registry registry:2 pull-through caches (migration).
-  docker rm -f registry-docker.io registry-quay.io registry-ghcr.io >/dev/null 2>&1 || true
-
   # Remove any stale (stopped) zot container; the named volume below keeps the
   # cached blobs, so recreating the container is cheap and picks up config edits.
   docker rm -f "${ZOT_HOST}" >/dev/null 2>&1 || true
@@ -143,14 +140,6 @@ pull-through-cache() {
     }
   }' > "${ZOT_DIR}/config.json"
 
-  # zot images are published per-arch (amd64|arm64). Use the full image (not
-  # -minimal) so the sync/search/ui extensions are present.
-  local arch
-  case "$(uname -m)" in
-    aarch64|arm64) arch=arm64 ;;
-    *)             arch=amd64 ;;
-  esac
-
   # Persistent blob store. docker here is DooD (the CLI talks to the host
   # daemon), so the devcontainer filesystem can't be bind-mounted; use a named
   # volume instead. It survives `docker rm`, so the cache persists across
@@ -166,7 +155,7 @@ pull-through-cache() {
     --restart always \
     -p "127.0.0.1:${ZOT_UI_PORT}:8080" \
     -v "${ZOT_VOLUME}:/var/lib/registry" \
-    "ghcr.io/project-zot/zot-linux-${arch}:v${ZOT_VERSION}" >/dev/null
+    "ghcr.io/project-zot/zot:v${ZOT_VERSION}" >/dev/null
   docker cp "${ZOT_DIR}/config.json" "${ZOT_HOST}:/etc/zot/config.json"
   docker start "${ZOT_HOST}" >/dev/null
 

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -34,6 +34,7 @@ readonly KUBERNETES_REPLICATOR_CHART_VERSION='2.12.3'  # https://artifacthub.io/
 readonly METRICS_SERVER_CHART_VERSION='3.13.0'         # https://artifacthub.io/packages/helm/metrics-server/metrics-server
 readonly ISTIO_CHART_VERSION='1.30.1'                  # https://artifacthub.io/packages/helm/istio-official/base
 readonly KIALI_CHART_VERSION='2.27.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
+readonly ZOT_VERSION='2.1.17'                          # https://github.com/project-zot/zot/releases
 
 #------------------------------------------------------------------------------
 # [i] Cleanup
@@ -64,6 +65,11 @@ cleanup() {
   docker ps -aq --filter name='^kindccm$' --filter name='^kindccm-' \
   | xargs -r docker rm -f >/dev/null 2>&1
 
+  # Stop the zot pull-through cache. Its blob store lives in the ${ZOT_VOLUME}
+  # named volume (left on disk), so a subsequent create does not re-download
+  # every image.
+  docker rm -f "${ZOT_HOST}" >/dev/null 2>&1 || true
+
   rm -rf ./tmp/*
 }
 
@@ -87,26 +93,84 @@ cloud-provider-kind() {
 }; SECTIONS+=( cloud-provider-kind )
 
 #------------------------------------------------------------------------------
-# [i] Pull-through image cache
+# [i] Pull-through image cache (zot)
 #------------------------------------------------------------------------------
 
 pull-through-cache() {
-  blue "───[ Pull-through registries ]──────────────────────────────────────────"
+  blue "───[ Pull-through cache (zot) ]─────────────────────────────────────────"
 
-  local -A registries=(
-    [docker.io]=https://registry-1.docker.io
-    [quay.io]=https://quay.io
-    [ghcr.io]=https://ghcr.io
+  # Already running? Nothing to do (its blob store persists across restarts).
+  if docker ps --format '{{.Names}}' | grep -qx "${ZOT_HOST}"; then
+    echo "zot already running, skipping install"
+    return 0
+  fi
+
+  # Drop any legacy per-registry registry:2 pull-through caches (migration).
+  docker rm -f registry-docker.io registry-quay.io registry-ghcr.io >/dev/null 2>&1 || true
+
+  # Remove any stale (stopped) zot container; the named volume below keeps the
+  # cached blobs, so recreating the container is cheap and picks up config edits.
+  docker rm -f "${ZOT_HOST}" >/dev/null 2>&1 || true
+
+  # Render config.json from the REGISTRIES map. Each upstream becomes an
+  # on-demand `sync` registry whose cached images live under its own destination
+  # prefix (the upstream host). `compat`/`preserveDigest` keep Docker media types
+  # intact so `image@sha256:` pulls still resolve. `search` + `ui` enable the
+  # bundled web interface (same binary, no extra component).
+  mkdir -p "${ZOT_DIR}"
+  local upstream registries_json
+  registries_json=$(
+    for upstream in "${!REGISTRIES[@]}"; do
+      jq -n --arg url "${REGISTRIES[${upstream}]}" --arg dest "/${upstream}" '{
+        urls: [$url],
+        onDemand: true,
+        tlsVerify: true,
+        preserveDigest: true,
+        content: [{ prefix: "**", destination: $dest }]
+      }'
+    done | jq -s '.'
   )
 
-  for name in "${!registries[@]}"; do
-    docker start "registry-${name}" 2>/dev/null || docker run -d \
-      -e REGISTRY_PROXY_REMOTEURL="${registries[${name}]}" \
-      --restart always \
-      --name "registry-${name}" \
-      --network kind \
-      registry:2
-  done
+  jq -n --argjson regs "${registries_json}" '{
+    distSpecVersion: "1.1.0",
+    storage: { rootDirectory: "/var/lib/registry", gc: true, dedupe: true },
+    http: { address: "0.0.0.0", port: "8080", compat: ["docker2s2"] },
+    log: { level: "info" },
+    extensions: {
+      sync: { enable: true, registries: $regs },
+      search: { enable: true },
+      ui: { enable: true }
+    }
+  }' > "${ZOT_DIR}/config.json"
+
+  # zot images are published per-arch (amd64|arm64). Use the full image (not
+  # -minimal) so the sync/search/ui extensions are present.
+  local arch
+  case "$(uname -m)" in
+    aarch64|arm64) arch=arm64 ;;
+    *)             arch=amd64 ;;
+  esac
+
+  # Persistent blob store. docker here is DooD (the CLI talks to the host
+  # daemon), so the devcontainer filesystem can't be bind-mounted; use a named
+  # volume instead. It survives `docker rm`, so the cache persists across
+  # `meshlab delete`.
+  docker volume create "${ZOT_VOLUME}" >/dev/null
+
+  # Create the container on the kind network (so nodes resolve it as ${ZOT_HOST})
+  # with the UI/API published on the host at ${ZOT_UI_PORT}, inject the rendered
+  # config (can't bind-mount under DooD), then start it.
+  docker create \
+    --name "${ZOT_HOST}" \
+    --network kind \
+    --restart always \
+    -p "127.0.0.1:${ZOT_UI_PORT}:8080" \
+    -v "${ZOT_VOLUME}:/var/lib/registry" \
+    "ghcr.io/project-zot/zot-linux-${arch}:v${ZOT_VERSION}" >/dev/null
+  docker cp "${ZOT_DIR}/config.json" "${ZOT_HOST}:/etc/zot/config.json"
+  docker start "${ZOT_HOST}" >/dev/null
+
+  echo "zot UI: http://127.0.0.1:${ZOT_UI_PORT}"
 }; SECTIONS+=( pull-through-cache )
 
 #------------------------------------------------------------------------------
@@ -163,34 +227,32 @@ create-clusters() {
 add-registries-to-containerd() {
   blue "───[ Configure containerd ]─────────────────────────────────────────────"
 
-  # Map registries to pull-through caches
-  echo "docker.io --> http://registry-docker.io:5000"
-  echo "quay.io   --> http://registry-quay.io:5000"
-  echo "ghcr.io   --> http://registry-ghcr.io:5000"
-
-  # Configure containerd in all clusters
+  # Route each upstream through its zot destination prefix. `override_path` makes
+  # containerd treat that path as the registry API root, so a pull of e.g.
+  # docker.io/library/nginx becomes a request to
+  # http://${ZOT_HOST}:${ZOT_PORT}/v2/docker.io/library/nginx. The `server` line
+  # keeps the real upstream as a fallback if zot is unreachable.
   for cluster in $(all_clusters); do (
-    docker exec -i "${cluster}-control-plane" bash -c '
-      mkdir -p /etc/containerd/certs.d/docker.io
-      cat <<- EOF > /etc/containerd/certs.d/docker.io/hosts.toml
-			server = "https://registry-1.docker.io"
-			[host."http://registry-docker.io:5000"]
-			  capabilities = ["pull", "resolve"]
-			EOF
-      mkdir -p /etc/containerd/certs.d/quay.io
-      cat <<- EOF > /etc/containerd/certs.d/quay.io/hosts.toml
-			server = "https://quay.io"
-			[host."http://registry-quay.io:5000"]
-			  capabilities = ["pull", "resolve"]
-			EOF
-      mkdir -p /etc/containerd/certs.d/ghcr.io
-      cat <<- EOF > /etc/containerd/certs.d/ghcr.io/hosts.toml
-			server = "https://ghcr.io"
-			[host."http://registry-ghcr.io:5000"]
-			  capabilities = ["pull", "resolve"]
-			EOF
-    '
+    local upstream url
+    for upstream in "${!REGISTRIES[@]}"; do
+      url="${REGISTRIES[${upstream}]}"
+      docker exec -i "${cluster}-control-plane" bash -c "
+        mkdir -p /etc/containerd/certs.d/${upstream}
+        printf '%s\n' \
+          'server = \"${url}\"' \
+          '[host.\"http://${ZOT_HOST}:${ZOT_PORT}/v2/${upstream}\"]' \
+          '  capabilities = [\"pull\", \"resolve\"]' \
+          '  override_path = true' \
+          > /etc/containerd/certs.d/${upstream}/hosts.toml
+      "
+    done
   ) & done; join
+
+  # Show the routing.
+  local upstream
+  for upstream in "${!REGISTRIES[@]}"; do
+    echo "${upstream} --> http://${ZOT_HOST}:${ZOT_PORT}/v2/${upstream}"
+  done
 }; SECTIONS+=( add-registries-to-containerd )
 
 #------------------------------------------------------------------------------

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -10,6 +10,10 @@ set -euo pipefail
 # Change to the execution directory
 cd "$(dirname "$0")"/..
 
+# Ensure the temporary directory exists
+HOST_TMP="${LOCAL_WORKSPACE_FOLDER}/.tmp"
+mkdir -p .tmp
+
 # shellcheck source=../lib/common.sh
 source ./lib/common.sh
 
@@ -65,12 +69,13 @@ cleanup() {
   docker ps -aq --filter name='^kindccm$' --filter name='^kindccm-' \
   | xargs -r docker rm -f >/dev/null 2>&1
 
-  # Stop the zot pull-through cache. Its blob store lives in the ${ZOT_VOLUME}
+  # Stop the zot pull-through cache. Its blob store lives in the zot-data
   # named volume (left on disk), so a subsequent create does not re-download
   # every image.
   docker rm -f "${ZOT_HOST}" >/dev/null 2>&1 || true
 
-  rm -rf ./tmp/*
+  # Remove the temporary directory
+  rm -rf .tmp
 }
 
 #------------------------------------------------------------------------------
@@ -96,12 +101,12 @@ cloud-provider-kind() {
 pull-through-cache() {
   blue "───[ Pull-through cache (zot) ]─────────────────────────────────────────"
 
-  # Render config.json from the REGISTRIES map (tab-separated upstream<TAB>url).
-  # Each upstream becomes an on-demand `sync` registry cached under its own
-  # prefix. `compat`/`preserveDigest` keep Docker media types intact for
-  # `image@sha256:` pulls; `search`/`ui` enable the bundled web interface.
-  mkdir -p "${ZOT_DIR}"
+  # Local variables
+  local ui_port=8086
+  local volume="zot-data"
   local upstream
+
+  # Render config.json from the REGISTRIES map
   for upstream in "${!REGISTRIES[@]}"; do
     printf '%s\t%s\n' "${upstream}" "${REGISTRIES[${upstream}]}"
   done | jq -R -s '{
@@ -122,21 +127,17 @@ pull-through-cache() {
       search: { enable: true },
       ui: { enable: true }
     }
-  }' > "${ZOT_DIR}/config.json"
+  }' > .tmp/zot-config.json
 
-  # Create the blob store volume and run zot. Under DooD the docker CLI talks to
-  # the host daemon, so the config bind-mount resolves on the host
-  # (${ZOT_DIR_HOST}) and the cache lives in a named volume that survives
-  # `docker rm`. zot joins the kind network (nodes resolve it as ${ZOT_HOST})
-  # and publishes its UI/API on the host; skip if already running.
-  docker volume create "${ZOT_VOLUME}" >/dev/null
+  # Create the blob store volume and run zot
+  docker volume create "${volume}" >/dev/null
   docker ps --format '{{.Names}}' | grep -qx "${ZOT_HOST}" || \
   docker run --rm -d \
     --name "${ZOT_HOST}" \
     --network kind \
-    -p "127.0.0.1:${ZOT_UI_PORT}:8080" \
-    -v "${ZOT_DIR_HOST}/config.json:/etc/zot/config.json:ro" \
-    -v "${ZOT_VOLUME}:/var/lib/registry" \
+    -p "127.0.0.1:${ui_port}:8080" \
+    -v "${HOST_TMP}/zot-config.json:/etc/zot/config.json:ro" \
+    -v "${volume}:/var/lib/registry" \
     "ghcr.io/project-zot/zot:v${ZOT_VERSION}" >/dev/null
 }; SECTIONS+=( pull-through-cache )
 
@@ -147,12 +148,9 @@ pull-through-cache() {
 create-clusters() {
   blue "───[ KinD clusters ]────────────────────────────────────────────────────"
 
-  # Create the temporary directory
-  [[ -d ./tmp ]] || mkdir -p ./tmp
-
   # Configure kind
   for cell in $(all_cells); do
-    cat <<- EOF > "./tmp/kind-${cell}.yaml"
+    cat <<- EOF > ".tmp/kind-${cell}.yaml"
 		kind: Cluster
 		apiVersion: kind.x-k8s.io/v1alpha4
 		networking:
@@ -176,7 +174,7 @@ create-clusters() {
   # Create the clusters
   for cluster in $(all_clusters); do (
     kind get clusters 2>/dev/null | grep -qx "${cluster}" || {
-      kind --kubeconfig ~/.kube/config.host create cluster --name "${cluster}" --config "./tmp/kind-${CELL_OF[${cluster}]}.yaml" -q
+      kind --kubeconfig ~/.kube/config.host create cluster --name "${cluster}" --config ".tmp/kind-${CELL_OF[${cluster}]}.yaml" -q
     }
   ) & done; join
 
@@ -857,7 +855,7 @@ tilt-up() {
       echo "tilt ${cluster} on port ${port} (running)"
     else
       setsid tilt up --context "kind-${cluster}" --port "${port}" \
-      &> "./tmp/tilt-${cluster}.log" &
+      &> ".tmp/tilt-${cluster}.log" &
       disown
       echo "tilt ${cluster} on port ${port} (started)"
     fi

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -79,17 +79,14 @@ cleanup() {
 
 cloud-provider-kind() {
   blue "───[ cloud-provider-kind ]──────────────────────────────────────────────"
-
   docker network ls | grep -q ' kind ' || \
   docker network create kind
-
-  docker ps --format '{{.Names}}' | grep -q '^kindccm$' || {
-    docker run --rm -d \
-      --name kindccm \
-      --network kind \
-      --volume /var/run/docker.sock:/var/run/docker.sock \
-      "registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v${KINDCCM_VERSION}"
-  }
+  docker ps --format '{{.Names}}' | grep -q '^kindccm$' || \
+  docker run --rm -d \
+    --name kindccm \
+    --network kind \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
+    "registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v${KINDCCM_VERSION}"
 }; SECTIONS+=( cloud-provider-kind )
 
 #------------------------------------------------------------------------------
@@ -120,7 +117,7 @@ pull-through-cache() {
           onDemand: true,
           tlsVerify: true,
           preserveDigest: true,
-          content: [{ prefix: "**", destination: "/" + .[0] }]
+          content: [{ prefix: "**", destination: ("/" + .[0]) }]
         })
       ) },
       search: { enable: true },
@@ -128,17 +125,12 @@ pull-through-cache() {
     }
   }' > "${ZOT_DIR}/config.json"
 
-  # Persistent blob store. docker here is DooD (the CLI talks to the host
-  # daemon), so use a named volume instead of a devcontainer-local path. It
-  # survives `docker rm`, so the cache persists across `meshlab delete`.
+  # Create the blob store volume and run zot. Under DooD the docker CLI talks to
+  # the host daemon, so the config bind-mount resolves on the host
+  # (${ZOT_DIR_HOST}) and the cache lives in a named volume that survives
+  # `docker rm`. zot joins the kind network (nodes resolve it as ${ZOT_HOST})
+  # and publishes its UI/API on the host; skip if already running.
   docker volume create "${ZOT_VOLUME}" >/dev/null
-
-  # Run zot on the kind network (so nodes resolve it as ${ZOT_HOST}) with the
-  # UI/API published on the host at ${ZOT_UI_PORT}. The rendered config is
-  # bind-mounted read-only from its host path (${ZOT_DIR_HOST}); under DooD the
-  # mount source resolves on the host filesystem, and the workspace is
-  # bind-mounted there, so the in-container ${ZOT_DIR} maps to ${ZOT_DIR_HOST}.
-  # Skip if already running (its blob store persists across restarts).
   docker ps --format '{{.Names}}' | grep -qx "${ZOT_HOST}" || \
   docker run --rm -d \
     --name "${ZOT_HOST}" \

--- a/charts/wftemplates/templates/argocd-sync-and-wait.yaml
+++ b/charts/wftemplates/templates/argocd-sync-and-wait.yaml
@@ -22,7 +22,7 @@ spec:
     inputs:
       parameters:
       - name: argocd-version
-        value: v3.3.7
+        value: v3.4.3
       - name: application-name
         value: ""
       - name: revision

--- a/docs/book/src/components/pull-through.md
+++ b/docs/book/src/components/pull-through.md
@@ -79,7 +79,7 @@ curl -s http://127.0.0.1:8086/v2/quay.io/argoproj/argocd/manifests/v2.4.7 | jq
 - zot is installed and started by the `pull-through-cache` section of
   `bin/meshlab`, and the clusters are wired to it by the
   `add-registries-to-containerd` section.
-- The rendered config lives in `./.zot/config.json` (gitignored). In this
+- The rendered config lives in `./.tmp/zot-config.json` (gitignored). In this
   devcontainer the Docker CLI talks to the host daemon (Docker-out-of-Docker), so
   the config is bind-mounted read-only from its host path (the workspace is
   bind-mounted into the devcontainer), and the cached blobs are kept in the

--- a/docs/book/src/components/pull-through.md
+++ b/docs/book/src/components/pull-through.md
@@ -6,12 +6,11 @@ upstream registry and cached; subsequent pulls of the same image are served from
 the cache instead of hitting the upstream again.
 
 This lab runs a single [zot](https://zotregistry.dev/) instance as the
-pull-through cache for every upstream registry, replacing the previous trio of
-`registry:2` containers. zot runs as a Docker container on the devcontainer host
-(attached to the `kind` network) so it is available before any cluster or CNI
-exists. It uses zot's `sync` extension in **on-demand** mode: an image is mirrored
-from the upstream only when it is first requested, then cached in zot's local
-blob store.
+pull-through cache for every upstream registry. zot runs as a Docker container on
+the devcontainer host (attached to the `kind` network) so it is available before
+any cluster or CNI exists. It uses zot's `sync` extension in **on-demand** mode:
+an image is mirrored from the upstream only when it is first requested, then
+cached in zot's local blob store.
 
 Each upstream is mirrored under its own destination prefix:
 

--- a/docs/book/src/components/pull-through.md
+++ b/docs/book/src/components/pull-through.md
@@ -20,6 +20,9 @@ Each upstream is mirrored under its own destination prefix:
 | `docker.io` | `/docker.io` | `https://registry-1.docker.io` |
 | `quay.io` | `/quay.io` | `https://quay.io` |
 | `ghcr.io` | `/ghcr.io` | `https://ghcr.io` |
+| `registry.k8s.io` | `/registry.k8s.io` | `https://registry.k8s.io` |
+| `registry.istio.io` | `/registry.istio.io` | `https://registry.istio.io` |
+| `ecr-public.aws.com` | `/ecr-public.aws.com` | `https://public.ecr.aws` |
 
 The upstreams are defined in a single associative array (`REGISTRIES`) in
 `lib/common.sh`; add more by adding a row there.
@@ -79,8 +82,9 @@ curl -s http://127.0.0.1:8086/v2/quay.io/argoproj/argocd/manifests/v2.4.7 | jq
   `add-registries-to-containerd` section.
 - The rendered config lives in `./.zot/config.json` (gitignored). In this
   devcontainer the Docker CLI talks to the host daemon (Docker-out-of-Docker), so
-  the config is injected with `docker cp` rather than bind-mounted, and the
-  cached blobs are kept in the `zot-data` Docker **named volume**.
+  the config is bind-mounted read-only from its host path (the workspace is
+  bind-mounted into the devcontainer), and the cached blobs are kept in the
+  `zot-data` Docker **named volume**.
 - The `zot` container is removed on `meshlab delete`, but the `zot-data` volume
   persists, so a subsequent `meshlab create` does not re-download every image.
 - To remove zot and its cache entirely:

--- a/docs/book/src/components/pull-through.md
+++ b/docs/book/src/components/pull-through.md
@@ -1,26 +1,91 @@
-# Pull-through registries
+# Pull-through cache (zot)
 
-A pull-through registry is a proxy that sits between your local Docker
-installation and a remote Docker registry. It caches the images you pull from
-the remote registry, and if another user on the same network tries to pull the
-same image, the pull-through registry will serve it to them directly, rather
-than pulling it again from the remote registry. The Container Runtime Interface
-(CRI) in this lab is set up to use local pull-through registries for the
-remote registries `docker.io`, `quay.io` and `ghcr.io` on each cluster.
+A pull-through cache is a proxy that sits between the clusters and the remote
+container registries. The first time an image is pulled it is fetched from the
+upstream registry and cached; subsequent pulls of the same image are served from
+the cache instead of hitting the upstream again.
 
-List all images in a registry:
-```console
-curl -s 127.0.0.1:5011/v2/_catalog | jq # docker.io
-curl -s 127.0.0.1:5012/v2/_catalog | jq # quay.io
-curl -s 127.0.0.1:5013/v2/_catalog | jq # ghcr.io
+This lab runs a single [zot](https://zotregistry.dev/) instance as the
+pull-through cache for every upstream registry, replacing the previous trio of
+`registry:2` containers. zot runs as a Docker container on the devcontainer host
+(attached to the `kind` network) so it is available before any cluster or CNI
+exists. It uses zot's `sync` extension in **on-demand** mode: an image is mirrored
+from the upstream only when it is first requested, then cached in zot's local
+blob store.
+
+Each upstream is mirrored under its own destination prefix:
+
+| Upstream | zot destination | Endpoint |
+|----------|-----------------|----------|
+| `docker.io` | `/docker.io` | `https://registry-1.docker.io` |
+| `quay.io` | `/quay.io` | `https://quay.io` |
+| `ghcr.io` | `/ghcr.io` | `https://ghcr.io` |
+
+The upstreams are defined in a single associative array (`REGISTRIES`) in
+`lib/common.sh`; add more by adding a row there.
+
+## How the clusters use it
+
+Each cluster's containerd is configured (via
+`/etc/containerd/certs.d/<upstream>/hosts.toml`) to mirror every upstream through
+its zot destination prefix, using `override_path = true` so the prefix becomes
+the registry API root:
+
+```toml
+server = "https://registry-1.docker.io"
+[host."http://zot:8080/v2/docker.io"]
+  capabilities = ["pull", "resolve"]
+  override_path = true
 ```
 
-List tags for a given image:
+A pull of `docker.io/library/nginx` is therefore served from
+`http://zot:8080/v2/docker.io/library/nginx`. The `server` line keeps the real
+upstream as a fallback if zot is unreachable.
+
+By-digest pulls (`image@sha256:...`) keep working because zot is configured with
+`compat: ["docker2s2"]` and the sync `preserveDigest` option, so Docker media
+types and digests are preserved instead of being rewritten to OCI.
+
+## Web UI
+
+zot's web interface and `/v2` API are published on the host:
+
+- URL: <http://127.0.0.1:8086>
+
+The UI is part of the same zot binary (the bundled `ui` + `search` extensions) —
+no extra component is required.
+
+## API examples
+
+List all cached repositories:
 ```console
-curl -s 127.0.0.1:5012/v2/argoproj/argocd/tags/list | jq
+curl -s http://127.0.0.1:8086/v2/_catalog | jq
+```
+
+List tags for a cached image (note the destination prefix):
+```console
+curl -s http://127.0.0.1:8086/v2/quay.io/argoproj/argocd/tags/list | jq
 ```
 
 Get the manifest for a given image and tag:
 ```console
-curl -s http://127.0.0.1:5012/v2/argoproj/argocd/manifests/v2.4.7 | jq
+curl -s http://127.0.0.1:8086/v2/quay.io/argoproj/argocd/manifests/v2.4.7 | jq
 ```
+
+## Lifecycle
+
+- zot is installed and started by the `pull-through-cache` section of
+  `bin/meshlab`, and the clusters are wired to it by the
+  `add-registries-to-containerd` section.
+- The rendered config lives in `./.zot/config.json` (gitignored). In this
+  devcontainer the Docker CLI talks to the host daemon (Docker-out-of-Docker), so
+  the config is injected with `docker cp` rather than bind-mounted, and the
+  cached blobs are kept in the `zot-data` Docker **named volume**.
+- The `zot` container is removed on `meshlab delete`, but the `zot-data` volume
+  persists, so a subsequent `meshlab create` does not re-download every image.
+- To remove zot and its cache entirely:
+
+  ```console
+  docker rm -f zot
+  docker volume rm zot-data
+  ```

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -27,17 +27,13 @@ declare -A CELL_OF=(
   [pizza-1]=pizza [pizza-2]=pizza
 )
 
-# Pull-through cache (zot). A single zot instance mirrors every upstream registry
-# on demand (its `sync` extension), replacing the per-registry registry:2
-# containers. ${ZOT_PORT} is the port the kind nodes reach over the kind docker
-# network; ${ZOT_UI_PORT} is the host-published port for the web UI and the /v2
-# API (kept off 8080 to avoid colliding with the socat-published service ports).
-# ${ZOT_DIR} is the in-container path where the config is rendered; ${ZOT_DIR_HOST}
-# is the same directory's path on the host. docker is DooD here (the CLI talks to
-# the host daemon), so bind-mount sources resolve on the host filesystem -- the
-# workspace is bind-mounted, so we mount the config from ${ZOT_DIR_HOST}.
-# ${ZOT_VOLUME} is a docker named volume for the blob store, so the cache
-# survives container removal.
+# Pull-through cache (zot). A single zot instance mirrors every upstream on
+# demand (`sync` extension). ${ZOT_PORT} is reached by the kind nodes over the
+# kind network; ${ZOT_UI_PORT} publishes the web UI and /v2 API on the host
+# (off 8080 to avoid colliding with socat-published service ports). The config
+# is rendered to ${ZOT_DIR} and bind-mounted from its host path ${ZOT_DIR_HOST}
+# (docker is DooD, so mount sources resolve on the host). ${ZOT_VOLUME} is a
+# named volume for the blob store, so the cache survives container removal.
 export ZOT_HOST="zot"
 export ZOT_PORT=8080
 export ZOT_UI_PORT=8086

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -27,6 +27,31 @@ declare -A CELL_OF=(
   [pizza-1]=pizza [pizza-2]=pizza
 )
 
+# Pull-through cache (zot). A single zot instance mirrors every upstream registry
+# on demand (its `sync` extension), replacing the per-registry registry:2
+# containers. ${ZOT_PORT} is the port the kind nodes reach over the kind docker
+# network; ${ZOT_UI_PORT} is the host-published port for the web UI and the /v2
+# API (kept off 8080 to avoid colliding with the socat-published service ports).
+# ${ZOT_DIR} holds the rendered config (docker is DooD here, so the config is
+# injected with `docker cp`, not bind-mounted). ${ZOT_VOLUME} is a docker named
+# volume for the blob store, so the cache survives container removal.
+export ZOT_HOST="zot"
+export ZOT_PORT=8080
+export ZOT_UI_PORT=8086
+export ZOT_DIR="${PWD}/.zot"
+export ZOT_VOLUME="zot-data"
+readonly ZOT_HOST ZOT_PORT ZOT_UI_PORT ZOT_DIR ZOT_VOLUME
+
+# zot proxy upstreams (single source of truth, easily extended). The key is BOTH
+# the upstream host (the containerd registry namespace) and the zot destination
+# path prefix; the value is the upstream registry URL.
+# shellcheck disable=SC2034 # used by bin/meshlab
+declare -A REGISTRIES=(
+  [docker.io]="https://registry-1.docker.io"
+  [quay.io]="https://quay.io"
+  [ghcr.io]="https://ghcr.io"
+)
+
 # Colors
 readonly CYAN='\e[1;36m'
 readonly DIM='\e[2m'

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -7,7 +7,9 @@
 export MNGR="mnger-1"
 export DOMAIN="demo.lab"
 export PASS='meshlab123'
-readonly MNGR DOMAIN PASS
+export ZOT_HOST="zot"
+export ZOT_PORT=8080
+readonly MNGR DOMAIN PASS ZOT_HOST ZOT_PORT
 export SECTIONS=()
 
 # Define workload cells and their clusters
@@ -27,24 +29,7 @@ declare -A CELL_OF=(
   [pizza-1]=pizza [pizza-2]=pizza
 )
 
-# Pull-through cache (zot). A single zot instance mirrors every upstream on
-# demand (`sync` extension). ${ZOT_PORT} is reached by the kind nodes over the
-# kind network; ${ZOT_UI_PORT} publishes the web UI and /v2 API on the host
-# (off 8080 to avoid colliding with socat-published service ports). The config
-# is rendered to ${ZOT_DIR} and bind-mounted from its host path ${ZOT_DIR_HOST}
-# (docker is DooD, so mount sources resolve on the host). ${ZOT_VOLUME} is a
-# named volume for the blob store, so the cache survives container removal.
-export ZOT_HOST="zot"
-export ZOT_PORT=8080
-export ZOT_UI_PORT=8086
-export ZOT_DIR="${PWD}/.zot"
-export ZOT_DIR_HOST="${LOCAL_WORKSPACE_FOLDER:-${PWD}}/.zot"
-export ZOT_VOLUME="zot-data"
-readonly ZOT_HOST ZOT_PORT ZOT_UI_PORT ZOT_DIR ZOT_DIR_HOST ZOT_VOLUME
-
-# zot proxy upstreams (single source of truth). The key is BOTH the upstream
-# host (containerd registry namespace) and the zot destination prefix; the
-# value is the upstream registry URL.
+# Map of known registries to their API endpoints
 # shellcheck disable=SC2034 # used by bin/meshlab
 declare -A REGISTRIES=(
   [docker.io]="https://registry-1.docker.io"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -32,15 +32,19 @@ declare -A CELL_OF=(
 # containers. ${ZOT_PORT} is the port the kind nodes reach over the kind docker
 # network; ${ZOT_UI_PORT} is the host-published port for the web UI and the /v2
 # API (kept off 8080 to avoid colliding with the socat-published service ports).
-# ${ZOT_DIR} holds the rendered config (docker is DooD here, so the config is
-# injected with `docker cp`, not bind-mounted). ${ZOT_VOLUME} is a docker named
-# volume for the blob store, so the cache survives container removal.
+# ${ZOT_DIR} is the in-container path where the config is rendered; ${ZOT_DIR_HOST}
+# is the same directory's path on the host. docker is DooD here (the CLI talks to
+# the host daemon), so bind-mount sources resolve on the host filesystem -- the
+# workspace is bind-mounted, so we mount the config from ${ZOT_DIR_HOST}.
+# ${ZOT_VOLUME} is a docker named volume for the blob store, so the cache
+# survives container removal.
 export ZOT_HOST="zot"
 export ZOT_PORT=8080
 export ZOT_UI_PORT=8086
 export ZOT_DIR="${PWD}/.zot"
+export ZOT_DIR_HOST="${LOCAL_WORKSPACE_FOLDER:-${PWD}}/.zot"
 export ZOT_VOLUME="zot-data"
-readonly ZOT_HOST ZOT_PORT ZOT_UI_PORT ZOT_DIR ZOT_VOLUME
+readonly ZOT_HOST ZOT_PORT ZOT_UI_PORT ZOT_DIR ZOT_DIR_HOST ZOT_VOLUME
 
 # zot proxy upstreams (single source of truth, easily extended). The key is BOTH
 # the upstream host (the containerd registry namespace) and the zot destination

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -46,14 +46,17 @@ export ZOT_DIR_HOST="${LOCAL_WORKSPACE_FOLDER:-${PWD}}/.zot"
 export ZOT_VOLUME="zot-data"
 readonly ZOT_HOST ZOT_PORT ZOT_UI_PORT ZOT_DIR ZOT_DIR_HOST ZOT_VOLUME
 
-# zot proxy upstreams (single source of truth, easily extended). The key is BOTH
-# the upstream host (the containerd registry namespace) and the zot destination
-# path prefix; the value is the upstream registry URL.
+# zot proxy upstreams (single source of truth). The key is BOTH the upstream
+# host (containerd registry namespace) and the zot destination prefix; the
+# value is the upstream registry URL.
 # shellcheck disable=SC2034 # used by bin/meshlab
 declare -A REGISTRIES=(
   [docker.io]="https://registry-1.docker.io"
   [quay.io]="https://quay.io"
   [ghcr.io]="https://ghcr.io"
+  [registry.k8s.io]="https://registry.k8s.io"
+  [registry.istio.io]="https://registry.istio.io"
+  [ecr-public.aws.com]="https://public.ecr.aws"
 )
 
 # Colors

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -9,7 +9,8 @@ export DOMAIN="demo.lab"
 export PASS='meshlab123'
 export ZOT_HOST="zot"
 export ZOT_PORT=8080
-readonly MNGR DOMAIN PASS ZOT_HOST ZOT_PORT
+export HOST_TMP="${LOCAL_WORKSPACE_FOLDER}/.tmp"
+readonly MNGR DOMAIN PASS ZOT_HOST ZOT_PORT HOST_TMP
 export SECTIONS=()
 
 # Define workload cells and their clusters


### PR DESCRIPTION
## Summary

Replaces the three `registry:2` pull-through cache containers (one each for `docker.io`, `quay.io`, `ghcr.io`) with a **single [zot](https://zotregistry.dev/) instance** running in on-demand `sync` mode, plus its bundled web UI. This shrinks the footprint from three containers to one small Go-binary container while making the upstream list trivially extensible.

## Why

The per-registry `registry:2` approach needs a new container for every upstream. With zot, all upstreams are driven by a single `REGISTRIES` map in `lib/common.sh`, so adding another registry is a one-line change. zot also gives us a browsable web UI for the cache.

## How it works

- **zot** runs on the `kind` docker network in on-demand mirror mode: an image is fetched from the upstream only on first request, then cached.
- **containerd** on every node routes each upstream through its zot destination prefix via `override_path = true` (e.g. `docker.io/library/nginx` -> `http://zot:8080/v2/docker.io/library/nginx`). The real upstream is kept as a `server` fallback if zot is down.
- **By-digest pulls** (`image@sha256:...`) keep working thanks to `http.compat=["docker2s2"]` + sync `preserveDigest`.
- **Web UI / `/v2` API** are published on the host at `http://127.0.0.1:8086` (bundled `ui` + `search` extensions -- no extra component).
- **Lifecycle** -- zot runs with `--rm` (no `--restart` policy): it is recreated on each `meshlab` run and removed when it stops or on `meshlab delete`. The `zot-data` named volume keeps the cached blobs across recreations, so a recreate never re-downloads everything. The "already running" check is folded into the `docker run` (same idiom as `cloud-provider-kind`), and the config is rendered in a single `jq` pass.

## Devcontainer note (Docker-out-of-Docker)

The devcontainer's Docker CLI targets the host daemon, so bind-mount sources resolve on the **host** filesystem, not on in-container paths. The workspace is bind-mounted, so the in-container `.tmp/` maps to its host path `HOST_TMP`, derived from `LOCAL_WORKSPACE_FOLDER`. That variable is now **required** -- the script fails fast if it is unset rather than silently bind-mounting a non-existent in-container path. The rendered `zot-config.json` is bind-mounted read-only from there, and the cache is persisted in the `zot-data` **named volume**. On `meshlab delete` the container is removed but the volume (cache) persists.

The zot container publishes its UI on the host at `127.0.0.1:8086` itself (via DooD), and the devcontainer is host-networked, so it reaches the UI directly. VS Code port forwarding is therefore not used for `8086`, and `.devcontainer/devcontainer.json` is left unchanged.

## Files changed

- `lib/common.sh` -- `REGISTRIES` single-source-of-truth map, plus the shared zot endpoint (`ZOT_HOST`, `ZOT_PORT=8080`) -- the only zot settings used across multiple stages. Per-stage settings (UI port, config path, blob volume) now live as locals in `pull-through-cache()`.
- `bin/meshlab` -- `ZOT_VERSION='2.1.17'`; a single `.tmp/` scratch dir (replaces the former `./tmp` + `.zot`), with `HOST_TMP` holding its host path for DooD bind mounts (requires `LOCAL_WORKSPACE_FOLDER`); rewrote `pull-through-cache()` (single-pass `jq` config rendered to `.tmp/zot-config.json`, multi-arch `ghcr.io/project-zot/zot` image, run with `--rm` and the running-guard folded into the `docker run`, config bind-mounted read-only + named volume for the blob store) and `add-registries-to-containerd()` (`override_path` routing); `cleanup()` removes the container but keeps the cache volume.
- `.gitignore` -- ignore `.tmp/` (consolidates the former `tmp/` + `.zot/`).
- `docs/book/src/components/pull-through.md` -- rewritten for the zot model; config path `.tmp/zot-config.json`.
- `.github/skills/open-webui/SKILL.md` -- added the Zot row + description mention.
- `charts/wftemplates/templates/argocd-sync-and-wait.yaml` -- bump the bundled Argo CD CLI to `v3.4.3`.
- `.devcontainer/Dockerfile` -- rewrite `archmap` as a heredoc for readability; drop the apt retry/timeout config.

## Verification

- `shellcheck -x bin/meshlab lib/common.sh` clean (only the pre-existing `SC1091` source note).
- Rendered `zot-config.json` is valid JSON with every upstream from `REGISTRIES`.
- Ran `meshlab run pull-through-cache` end-to-end: zot boots, `zot-data` volume created, **on-demand sync pulled and cached `docker.io/library/busybox` (HTTP 200)**, UI returns HTTP 200.
- Dry-ran the generated `hosts.toml` for each upstream.
