### PR TITLE
Route Helm charts through zot OCI cache; drop helm repo step

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,8 +55,9 @@ RUN echo 'dind() { docker -H unix:///var/run/docker.sock "$@" }' >> /etc/zsh/zsh
     echo "source <(docker completion zsh)" >> /etc/zsh/zshrc && \
     echo "compdef _docker dind dood" >> /etc/zsh/zshrc
 
-# Enable zsh completion for the meshlab CLI (bin/meshlab)
-RUN echo "source <(meshlab completion zsh)" >> /etc/zsh/zshrc
+# Enable zsh completion for the meshlab CLI (bin/meshlab).
+RUN echo "source <(meshlab completion zsh)" >> /root/.zshrc && \
+    echo "source <(meshlab completion zsh)" >> /home/vscode/.zshrc
 
 # Install Go (https://go.dev/dl/)
 RUN VERSION="1.26.4" && ARCH=$(archmap 'arm64' 'amd64') && \

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -91,7 +91,6 @@ pull-through-cache() {
   blue "───[ Pull-through cache (zot) ]─────────────────────────────────────────"
 
   # Local variables
-  local ui_port=8086
   local volume="zot-data"
   local upstream
 
@@ -124,13 +123,13 @@ pull-through-cache() {
   docker run --rm -d \
     --name "${ZOT_HOST}" \
     --network kind \
-    -p "127.0.0.1:${ui_port}:8080" \
+    -p "127.0.0.1:${ZOT_LOCAL_PORT}:8080" \
     -v "${HOST_TMP}/zot-config.json:/etc/zot/config.json:ro" \
     -v "${volume}:/var/lib/registry" \
     "ghcr.io/project-zot/zot:v${ZOT_VERSION}" >/dev/null
 
   # Show the zot UI URL
-  echo "zot --> http://127.0.0.1:${ui_port}"
+  echo "zot --> http://${ZOT_LOCAL}"
 }; SECTIONS+=( pull-through-cache )
 
 #------------------------------------------------------------------------------
@@ -247,17 +246,6 @@ setup-kubeconfig() {
 }; SECTIONS+=( setup-kubeconfig )
 
 #------------------------------------------------------------------------------
-# [i] Helm repositories
-#------------------------------------------------------------------------------
-
-helm-repositories() {
-  blue "───[ Helm repos ]───────────────────────────────────────────────────────"
-  retry helm repo add argo https://argoproj.github.io/argo-helm
-  retry helm repo add k8s_gateway https://k8s-gateway.github.io/k8s_gateway/
-  retry helm repo update
-}; SECTIONS+=( helm-repositories )
-
-#------------------------------------------------------------------------------
 # [i] Setup the per-cell flat network
 #------------------------------------------------------------------------------
 
@@ -299,7 +287,8 @@ install-k8s-gateway() {
   blue "───[ k8s_gateway ]──────────────────────────────────────────────────────"
   for cluster in $(all_clusters); do (
     retry helm --kube-context "kind-${cluster}" \
-      upgrade -i exdns k8s_gateway/k8s-gateway \
+      upgrade -i exdns --plain-http \
+      "oci://${ZOT_LOCAL}/ghcr.io/k8s-gateway/charts/k8s-gateway" \
       --version "${K8S_GATEWAY_CHART_VERSION}" \
       --namespace kube-system \
       --set "domain=${DOMAIN}" |
@@ -376,7 +365,8 @@ setup-argocd() {
 
   # Install ArgoCD
   h0 upgrade --install -n argocd --create-namespace --wait --timeout 5m \
-  argocd argo/argo-cd --version "${ARGOCD_CHART_VERSION}" \
+  argocd --plain-http "oci://${ZOT_LOCAL}/ghcr.io/argoproj/argo-helm/argo-cd" \
+  --version "${ARGOCD_CHART_VERSION}" \
   --set 'server.service.type=LoadBalancer' \
   --set 'server.extraArgs={--insecure=true}' \
   --set configs.secret.argocdServerAdminPassword="$(htpasswd -nbBC 10 "" "${PASS}" | tr -d ':\n')" \
@@ -468,7 +458,9 @@ setup-argowf() {
 
   # Install Argo Workflows
   h0 upgrade --install -n argowf --create-namespace --wait --timeout 5m \
-    argo-workflows argo/argo-workflows --version "${ARGOWF_CHART_VERSION}" \
+    argo-workflows --plain-http \
+    "oci://${ZOT_LOCAL}/ghcr.io/argoproj/argo-helm/argo-workflows" \
+    --version "${ARGOWF_CHART_VERSION}" \
     --set 'server.serviceType=LoadBalancer' \
     --set 'server.authModes={server}' \
     --set 'server.servicePort=80' \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -9,8 +9,10 @@ export DOMAIN="demo.lab"
 export PASS='meshlab123'
 export ZOT_HOST="zot"
 export ZOT_PORT=8080
+export ZOT_LOCAL_PORT=8086
+export ZOT_LOCAL="127.0.0.1:${ZOT_LOCAL_PORT}"
 export HOST_TMP="${LOCAL_WORKSPACE_FOLDER}/.tmp"
-readonly MNGR DOMAIN PASS ZOT_HOST ZOT_PORT HOST_TMP
+readonly MNGR DOMAIN PASS ZOT_HOST ZOT_PORT ZOT_LOCAL_PORT ZOT_LOCAL HOST_TMP
 export SECTIONS=()
 
 # Define workload cells and their clusters


### PR DESCRIPTION
## Summary

Migrates the three remotely-pulled Helm charts from classic HTTP chart repositories to their **OCI equivalents on `ghcr.io`**, pulled through the existing **zot pull-through cache** via `--plain-http`.

This removes `helm-repositories()` — the `helm repo add argo` + `helm repo update` step that fetches `index.yaml` from GitHub Pages and was the source of transient `EOF` failures (e.g. `Get "https://argoproj.github.io/argo-helm/index.yaml": EOF`).

## Why

- `ghcr.io` is already in the `REGISTRIES` map, so zot's `onDemand` sync caches these charts with **no config change**.
- Charts now get the same caching/dedup as container images.
- Eliminates the dependency on the flaky GitHub Pages `index.yaml` protocol (zot is OCI-only and cannot proxy it).

## Changes

**`lib/common.sh`**
- Added a devcontainer-facing zot endpoint constant: `ZOT_LOCAL_PORT=8086` / `ZOT_LOCAL="127.0.0.1:${ZOT_LOCAL_PORT}"`. The devcontainer is not on the `kind` network, so the `zot` hostname doesn't resolve here — pulls go through the published port.

**`bin/meshlab`**
- `pull-through-cache()`: dropped the local `ui_port`; now uses the shared `ZOT_LOCAL_PORT` / `ZOT_LOCAL` (single source of truth).
- **Removed `helm-repositories()`** and its `SECTIONS` entry.
- Repointed installs to OCI-through-zot:
  - `install-k8s-gateway` → `oci://${ZOT_LOCAL}/ghcr.io/k8s-gateway/charts/k8s-gateway --plain-http`
  - `setup-argocd` → `oci://${ZOT_LOCAL}/ghcr.io/argoproj/argo-helm/argo-cd --plain-http`
  - `setup-argowf` → `oci://${ZOT_LOCAL}/ghcr.io/argoproj/argo-helm/argo-workflows --plain-http`

`pull-through-cache` runs early in `SECTIONS`, so zot is up before any chart pull.

## Validation

- `bash -n` clean on both files; shellcheck shows only the pre-existing SC1091 (source-path info), unrelated to these changes.
- Full `helm pull` through zot succeeded for all three charts at their pinned versions (real blob fetch, not just manifest):
  - `argo-cd` 9.5.20 ✅
  - `argo-workflows` 1.0.14 ✅
  - `k8s-gateway` 3.7.1 ✅

## Notes

No direct-`ghcr.io` fallback was added — everything routes through zot (consistent with the rest of the lab), and the `retry`/`h0` wrappers still cover transient blips.
