### PR TITLE
Upgrade meshlab components

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,7 +60,7 @@ RUN echo "source <(meshlab completion zsh)" >> /root/.zshrc && \
     echo "source <(meshlab completion zsh)" >> /home/vscode/.zshrc
 
 # Install Go (https://go.dev/dl/)
-RUN VERSION="1.26.4" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="1.26.5" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL https://go.dev/dl/go${VERSION}.linux-${ARCH}.tar.gz | tar -xzC /usr/local && \
     echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/zsh/zshenv && \
     echo 'export PATH=$PATH:$HOME/go/bin' >> /etc/zsh/zshenv
@@ -71,13 +71,13 @@ RUN VERSION="v0.32.0" && ARCH=$(archmap 'arm64' 'amd64') && \
     chmod +x /usr/local/bin/kind && echo "source <(kind completion zsh)" >> /etc/zsh/zshrc
 
 # Install kubectl (https://cdn.dl.k8s.io/release/stable.txt)
-RUN VERSION="v1.36.1" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="v1.36.2" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /usr/local/bin/kubectl https://dl.k8s.io/release/${VERSION}/bin/linux/${ARCH}/kubectl && \
     chmod +x /usr/local/bin/kubectl && ln -s /usr/local/bin/kubectl /usr/local/bin/k && \
     echo "source <(kubectl completion zsh)" >> /etc/zsh/zshrc
 
 # Install helm (https://github.com/helm/helm/releases)
-RUN VERSION="v4.2.0" && \
+RUN VERSION="v4.2.3" && \
     $CURL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/${VERSION}/scripts/get-helm-4 && \
     chmod 700 /tmp/get_helm.sh && /tmp/get_helm.sh --version ${VERSION} && rm -f /tmp/get_helm.sh && \
     echo "source <(helm completion zsh)" >> /etc/zsh/zshrc
@@ -88,35 +88,35 @@ RUN VERSION="v4.53.3" && ARCH=$(archmap 'arm64' 'amd64') && \
     chmod +x /usr/local/bin/yq && echo "source <(yq completion zsh)" >> /etc/zsh/zshrc
 
 # Install argocd (https://github.com/argoproj/argo-cd/releases)
-RUN VERSION="v3.4.3" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="v3.4.5" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/${VERSION}/argocd-linux-${ARCH} && \
     chmod +x /usr/local/bin/argocd && echo "source <(argocd completion zsh)" >> /etc/zsh/zshrc
 
 # Install argo (https://github.com/argoproj/argo-workflows/releases)
-RUN VERSION="v4.0.5" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="v4.0.7" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL https://github.com/argoproj/argo-workflows/releases/download/${VERSION}/argo-linux-${ARCH}.gz | gunzip -c > /usr/local/bin/argo && \
     chmod +x /usr/local/bin/argo && echo "source <(argo completion zsh)" >> /etc/zsh/zshrc
 
 # Install istioctl (https://github.com/istio/istio/releases)
-RUN VERSION="1.30.1" && ARCH=$(archmap 'arm64' 'amd64') && \
+RUN VERSION="1.30.3" && ARCH=$(archmap 'arm64' 'amd64') && \
     $CURL -o /tmp/istio.tar.gz https://github.com/istio/istio/releases/download/${VERSION}/istio-${VERSION}-linux-${ARCH}.tar.gz && \
     tar -xC /usr/local/bin --strip-components 2 -f /tmp/istio.tar.gz istio-${VERSION}/bin/istioctl && rm -f /tmp/istio.tar.gz && \
     echo "source <(istioctl completion zsh)" >> /etc/zsh/zshrc
 
 # Install step (https://github.com/smallstep/cli/releases)
-RUN VERSION="0.30.2" && ARCH=$(archmap 'arm64' 'amd64') && cd /tmp && \
+RUN VERSION="0.30.6" && ARCH=$(archmap 'arm64' 'amd64') && cd /tmp && \
     $CURL -O https://dl.smallstep.com/gh-release/cli/gh-release-header/v${VERSION}/step-cli_${VERSION}-1_${ARCH}.deb && \
     dpkg -i step-cli_${VERSION}-1_${ARCH}.deb && rm -f step-cli_${VERSION}-1_${ARCH}.deb && \
     echo "source <(step completion zsh)" >> /etc/zsh/zshrc
 
 # Install gh (https://github.com/cli/cli/releases)
-RUN VERSION="2.93.0" && ARCH=$(archmap 'arm64' 'amd64') && cd /tmp && \
+RUN VERSION="2.96.0" && ARCH=$(archmap 'arm64' 'amd64') && cd /tmp && \
     $CURL -O https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_${ARCH}.deb && \
     dpkg -i gh_${VERSION}_linux_${ARCH}.deb && rm -f gh_${VERSION}_linux_${ARCH}.deb && \
     echo "source <(gh completion -s zsh)" >> /etc/zsh/zshrc
 
 # Install mdbook (https://github.com/rust-lang/mdBook/releases)
-RUN VERSION="v0.5.3" && ARCH=$(archmap 'aarch64' 'x86_64') && \
+RUN VERSION="v0.5.4" && ARCH=$(archmap 'aarch64' 'x86_64') && \
     $CURL https://github.com/rust-lang/mdbook/releases/download/${VERSION}/mdbook-${VERSION}-${ARCH}-unknown-linux-musl.tar.gz | \
     tar -xzC /usr/local/bin mdbook && echo "source <(mdbook completions zsh)" >> /etc/zsh/zshrc
 
@@ -131,12 +131,12 @@ RUN VERSION="1.4.7" && ARCH=$(archmap 'aarch64' 'x86_64') && \
     tar -xzC /usr/local/bin --strip-components 3 -f - ./btop/bin/btop
 
 # Install tilt (https://github.com/tilt-dev/tilt/releases)
-RUN VERSION="0.37.3" && ARCH=$(archmap 'arm64' 'x86_64') && \
+RUN VERSION="0.37.5" && ARCH=$(archmap 'arm64' 'x86_64') && \
     $CURL https://github.com/tilt-dev/tilt/releases/download/v${VERSION}/tilt.${VERSION}.linux.${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin tilt && echo "source <(tilt completion zsh)" >> /etc/zsh/zshrc
 
 # Install crane (https://github.com/google/go-containerregistry/releases)
-RUN VERSION="v0.21.6" && ARCH=$(archmap 'arm64' 'x86_64') && \
+RUN VERSION="v0.21.7" && ARCH=$(archmap 'arm64' 'x86_64') && \
     $CURL https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_${ARCH}.tar.gz | \
     tar -xzC /usr/local/bin crane && echo "source <(crane completion zsh)" >> /etc/zsh/zshrc
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -15,8 +15,8 @@ allow_k8s_contexts([
 # Variables
 #------------------------------------------------------------------------------
 
-version_dash = '1-30-1'
-version_dot = '1.30.1'
+version_dash = '1-30-3'
+version_dot = '1.30.3'
 image_ref = 'pilot-discovery-dev'
 cluster_name = k8s_context().removeprefix('kind-')
 

--- a/bin/meshlab
+++ b/bin/meshlab
@@ -23,20 +23,20 @@ NET_START=$(net_bytes)
 # [i] Versions
 #------------------------------------------------------------------------------
 
-readonly KINDCCM_VERSION='0.10.0'                      # https://github.com/kubernetes-sigs/cloud-provider-kind/releases
-readonly K8S_GATEWAY_CHART_VERSION='3.7.1'             # https://github.com/k8s-gateway/k8s_gateway/blob/master/charts/k8s-gateway/Chart.yaml
-readonly ARGOCD_CHART_VERSION='9.5.20'                 # https://artifacthub.io/packages/helm/argo-cd-oci/argo-cd
-readonly ARGOWF_CHART_VERSION='1.0.14'                 # https://artifacthub.io/packages/helm/argo/argo-workflows
-readonly PROMETHEUS_CHART_VERSION='29.10.1'            # https://artifacthub.io/packages/helm/prometheus-community/prometheus
+readonly KINDCCM_VERSION='0.11.1'                      # https://github.com/kubernetes-sigs/cloud-provider-kind/releases
+readonly K8S_GATEWAY_CHART_VERSION='3.7.2'             # https://github.com/k8s-gateway/k8s_gateway/blob/master/charts/k8s-gateway/Chart.yaml
+readonly ARGOCD_CHART_VERSION='10.1.4'                 # https://artifacthub.io/packages/helm/argo-cd-oci/argo-cd
+readonly ARGOWF_CHART_VERSION='1.0.20'                 # https://artifacthub.io/packages/helm/argo/argo-workflows
+readonly PROMETHEUS_CHART_VERSION='29.18.0'            # https://artifacthub.io/packages/helm/prometheus-community/prometheus
 readonly GRAFANA_CHART_VERSION='10.5.15'               # https://artifacthub.io/packages/helm/grafana/grafana
-readonly OTEL_COLLECTOR_CHART_VERSION='0.158.1'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
-readonly VAULT_CHART_VERSION='0.33.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
-readonly CERT_MANAGER_CHART_VERSION='v1.20.2'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
-readonly KUBERNETES_REPLICATOR_CHART_VERSION='2.12.3'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
-readonly METRICS_SERVER_CHART_VERSION='3.13.0'         # https://artifacthub.io/packages/helm/metrics-server/metrics-server
-readonly ISTIO_CHART_VERSION='1.30.1'                  # https://artifacthub.io/packages/helm/istio-official/base
-readonly KIALI_CHART_VERSION='2.27.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
-readonly ZOT_VERSION='2.1.17'                          # https://github.com/project-zot/zot/releases
+readonly OTEL_COLLECTOR_CHART_VERSION='0.165.0'        # https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector
+readonly VAULT_CHART_VERSION='0.34.0'                  # https://artifacthub.io/packages/helm/hashicorp/vault
+readonly CERT_MANAGER_CHART_VERSION='v1.21.0'          # https://artifacthub.io/packages/helm/cert-manager/cert-manager
+readonly KUBERNETES_REPLICATOR_CHART_VERSION='2.12.4'  # https://artifacthub.io/packages/helm/kubernetes-replicator/kubernetes-replicator
+readonly METRICS_SERVER_CHART_VERSION='3.13.1'         # https://artifacthub.io/packages/helm/metrics-server/metrics-server
+readonly ISTIO_CHART_VERSION='1.30.3'                  # https://artifacthub.io/packages/helm/istio-official/base
+readonly KIALI_CHART_VERSION='2.29.0'                  # https://artifacthub.io/packages/helm/kiali/kiali-operator
+readonly ZOT_VERSION='2.1.18'                          # https://github.com/project-zot/zot/releases
 
 #------------------------------------------------------------------------------
 # [i] Cleanup

--- a/charts/wftemplates/templates/argocd-sync-and-wait.yaml
+++ b/charts/wftemplates/templates/argocd-sync-and-wait.yaml
@@ -22,7 +22,7 @@ spec:
     inputs:
       parameters:
       - name: argocd-version
-        value: v3.4.3
+        value: v3.4.5
       - name: application-name
         value: ""
       - name: revision


### PR DESCRIPTION
Upgrade MeshLab's Helm charts, runtime components, and devcontainer CLI tools to their latest stable releases.

### Helm Charts (`bin/meshlab`)

| Component | Previous | Latest | Status |
|---|---:|---:|---|
| cloud-provider-kind | 0.10.0 | 0.11.1 | Upgraded |
| k8s-gateway | 3.7.1 | 3.7.2 | Upgraded |
| Argo CD | 9.5.20 | 10.1.4 | Upgraded |
| Argo Workflows | 1.0.14 | 1.0.20 | Upgraded |
| Prometheus | 29.10.1 | 29.18.0 | Upgraded |
| OpenTelemetry Collector | 0.158.1 | 0.165.0 | Upgraded |
| Vault | 0.33.0 | 0.34.0 | Upgraded |
| cert-manager | v1.20.2 | v1.21.0 | Upgraded |
| kubernetes-replicator | 2.12.3 | 2.12.4 | Upgraded |
| metrics-server | 3.13.0 | 3.13.1 | Upgraded |
| Istio | 1.30.1 | 1.30.3 | Upgraded |
| Kiali Operator | 2.27.0 | 2.29.0 | Upgraded |
| Zot | 2.1.17 | 2.1.18 | Upgraded |

### CLI Tools (`.devcontainer/Dockerfile`)

| Tool | Previous | Latest | Status |
|---|---:|---:|---|
| Go | 1.26.4 | 1.26.5 | Upgraded |
| kubectl | v1.36.1 | v1.36.2 | Upgraded |
| Helm | v4.2.0 | v4.2.3 | Upgraded |
| argocd | v3.4.3 | v3.4.5 | Upgraded |
| argo | v4.0.5 | v4.0.7 | Upgraded |
| istioctl | 1.30.1 | 1.30.3 | Upgraded |
| step | 0.30.2 | 0.30.6 | Upgraded |
| gh | 2.93.0 | 2.96.0 | Upgraded |
| mdBook | v0.5.3 | v0.5.4 | Upgraded |
| Tilt | 0.37.3 | 0.37.5 | Upgraded |
| crane | v0.21.6 | v0.21.7 | Upgraded |

Grafana, kind, yq, swarmctl, btop, grafanactl, and bat were already current.

### Istio

- Keep the chart, `istioctl`, and Tilt pins synchronized at `1.30.3`.
- Sync `/workspaces/istio` to upstream tag `1.30.3`.
- Publish multi-architecture debug and distroless images to `ghcr.io/h0tbird`.
- Rebuild the local Istio binaries used by Tilt.

### Validation

- `bash -n bin/meshlab`
- `shellcheck -e SC1091,SC2317 bin/meshlab`
- Istio pin consistency check
- `git diff --check`
- `make istio-images ISTIO_HUB=ghcr.io/h0tbird ISTIO_TAG=1.30.3`
- `make istio-binaries`
- Rebuilt `pilot-discovery` reports Git tag `1.30.3` and clean build status

### Notes

- Argo CD chart `9.5.20 -> 10.1.4` is a major chart upgrade.
- After deployment, compare the embedded istiod Deployment in `Tiltfile` with Argo CD's rendered diff and port any non-Tilt-specific upstream manifest changes.